### PR TITLE
Make "standup" optional in DMs; user feedback when submitting a standup

### DIFF
--- a/lib/bot/getUserStandupInfo.js
+++ b/lib/bot/getUserStandupInfo.js
@@ -4,8 +4,8 @@ var timeHelper = require('../helpers').time;
 var models = require('../../models');
 
 function getUserStandupInfo(bot, message) {
-  var standupChannel = message.match[1];
-  var content = message.match[2];
+  var standupChannel = message.match[2];
+  var content = message.match[3];
   if (standupChannel[0] === 'C'){
     models.Channel.findOne({
       where: {
@@ -76,7 +76,7 @@ function attachListener(controller) {
   // TODO: allow multiple ways to separate messages (i.e. \n or ; or |)
   // TODO: update reports when edited
   // TODO: parse standup messages
-  controller.hears(['standup <#(\\S*)>((.|\n)*)'],['direct_message'], getUserStandupInfo);
+  controller.hears(['(standup )?<#(\\S*)>((.|\n)*)'],['direct_message'], getUserStandupInfo);
 }
 
 module.exports = attachListener;

--- a/lib/bot/getUserStandupInfo.js
+++ b/lib/bot/getUserStandupInfo.js
@@ -1,11 +1,14 @@
 'use strict';
 
+var moment = require('moment');
 var timeHelper = require('../helpers').time;
 var models = require('../../models');
 
 function getUserStandupInfo(bot, message) {
   var standupChannel = message.match[2];
   var content = message.match[3];
+  var localReport = '';
+
   if (standupChannel[0] === 'C'){
     models.Channel.findOne({
       where: {
@@ -25,25 +28,32 @@ function getUserStandupInfo(bot, message) {
           var today = standup.today;
           var blockers = standup.blockers;
           var goal = standup.goal;
+
           for (var note in notes) {
+            localReport += '\n\n';
             var item = notes[note].replace(/\n/g,'');
             switch (item.toLowerCase()[0]) {
               case 'y':
-              yesterday = item;
-              break;
+                localReport += '*Yesterday*\n' + item;
+                yesterday = item;
+                break;
               case 't':
-              today = item;
-              break;
+                localReport += '*Today*\n' + item;
+                today = item;
+                break;
               case 'b':
-              blockers = item;
-              break;
+                localReport += '*Blockers*\n' + item;
+                blockers = item;
+                break;
               case 'g':
-              goal = item;
-              break;
+                localReport += '*Goal*\n' + item;
+                goal = item;
+                break;
               default:
-              console.log('no match for '+item);
+                console.log('no match for '+item);
             }
           }
+
           return models.Standup.update(
             {
               yesterday: yesterday,
@@ -59,7 +69,16 @@ function getUserStandupInfo(bot, message) {
               }
             });
         }).then(function () {
-          bot.reply(message,'Thanks! Your standup for <#'+standupChannel+'> is recorded');
+          // Time has to be 4 digits for moment
+          // to parse it properly
+          let time = String(channel.time);
+          if(time.length < 4) {
+            time = '0' + time;
+          }
+
+          bot.reply(message, 'Thanks! Your standup for <#'+standupChannel+'> is recorded and will be reported at ' +
+            timeHelper.getDisplayFormat(moment(time, 'HHmm')) +
+            '.  It will look like:' + localReport);
         });
       } else {
         return bot.reply(message,

--- a/lib/helpers/time.js
+++ b/lib/helpers/time.js
@@ -31,7 +31,7 @@ function getDisplayFormat(time) {
   if(!time) {
     time = new Date();
   }
-  return moment(time).format('hh:mm a');
+  return moment(time).format('h:mm a');
 }
 
 module.exports = {


### PR DESCRIPTION
For DMs to the bot, the prefix "standup" is now optional.  Not totally removed since some users may already be used to it and this would break their pattern.

After a standup is received, the bot lets the user know when it will be reported and shows them what it will look like:

![screen shot 2016-03-01 at 9 17 12 am](https://cloud.githubusercontent.com/assets/1775733/13431691/0839c16e-df90-11e5-8d7e-d52bc9a67f92.png)

(The time display in that screenshot is incorrect.  The UTC offset is not displayed.)

Also updates the time display format to single-digit 12-hour instead of double-digit 12-hour.  E.g., "7:30 am" instead of "07:30 am."
