### PR TITLE
Sort of handle timezones

### DIFF
--- a/lib/bot/createStandup.js
+++ b/lib/bot/createStandup.js
@@ -16,7 +16,7 @@ function createStandup(bot, message) {
       }).then(function () {
         models.Channel.update(
           {
-            time: timeHelper.getScheduleFormat(time)
+            time: timeHelper.getUTCTimeAssumingEastern(timeHelper.getScheduleFormat(time))
           },
           {
             where: {
@@ -25,7 +25,7 @@ function createStandup(bot, message) {
           }
         );
         return bot.reply(message,
-          'Got it. Standup scheduled for '+timeHelper.getDisplayFormat(time)
+          'Got it. Standup scheduled for '+timeHelper.getDisplayFormat(time)+' eastern'
         );
       });
     } else {

--- a/lib/bot/getReportRunner.js
+++ b/lib/bot/getReportRunner.js
@@ -4,10 +4,11 @@ var asyncLib = require('async');
 var un = require('underscore');
 var moment = require('moment');
 var models = require('../../models');
+var helpers = require('../helpers');
 var fedHolidays = require('@18f/us-federal-holidays');
 
 function runReports(anytimeBot) {
-  var time = moment().format('HHmm');
+  var time = helpers.time.getCurrentUTCTime();
   var date = moment().format('YYYY-MM-DD');
 
   // Don't run if today is a federal holiday

--- a/lib/helpers/time.js
+++ b/lib/helpers/time.js
@@ -2,6 +2,32 @@
 
 var moment = require('moment');
 
+function getFourDigitTime(time) {
+  time = String(time);
+  while(time.length < 4) {
+    time = '0' + time;
+  }
+  return time;
+}
+
+function getUTCTimeAssumingEastern(baseTime) {
+  baseTime = baseTime.substr(0, 2) + ':' + baseTime.substr(2);
+  var now = new Date();
+
+  // Use the current date, and append the time.  Let Javascript figure
+  // out the correct UTC time from that, taking dates and junk into account.
+  var parseableString = (now.getUTCMonth() + 1) + '/' + now.getUTCDate() + '/' + now.getUTCFullYear() + ' ' + baseTime + ' EST';
+  var easternTime = new Date(Date.parse(parseableString));
+  var utcTime = (easternTime.getUTCHours() * 100) + easternTime.getUTCMinutes();
+
+  return getFourDigitTime(utcTime);
+}
+
+function getCurrentUTCTime() {
+  var now = new Date();
+  return getFourDigitTime(String(now.getUTCHours()) + String(now.getUTCMinutes()));
+}
+
 function getTimeFromString(str) {
   var time = str.match(/((\d+|:)*(\s)?((a|p)m)|\d{4})/gi);
   if(time) {
@@ -38,5 +64,7 @@ module.exports = {
   getTimeFromString: getTimeFromString,
   getScheduleFormat: getScheduleFormat,
   getDisplayFormat: getDisplayFormat,
-  getReportFormat: getReportFormat
+  getReportFormat: getReportFormat,
+  getCurrentUTCTime: getCurrentUTCTime,
+  getUTCTimeAssumingEastern: getUTCTimeAssumingEastern
 };


### PR DESCRIPTION
Assumes user input is in eastern timezone (either standard or daylight savings, depending on which is active).  Converts that to UTC for storage and comparison.  The cron checks now look for any standups that need to report at the current time, in UTC.

Also added a note indicating that times are in eastern when the bot creates a new standup.
