### PR TITLE
Use moment-timezone plugin

### DIFF
--- a/lib/bot/createStandup.js
+++ b/lib/bot/createStandup.js
@@ -16,7 +16,7 @@ function createStandup(bot, message) {
       }).then(function () {
         models.Channel.update(
           {
-            time: timeHelper.getUTCTimeAssumingEastern(timeHelper.getScheduleFormat(time))
+            time: timeHelper.getScheduleFormat(time)
           },
           {
             where: {
@@ -25,7 +25,7 @@ function createStandup(bot, message) {
           }
         );
         return bot.reply(message,
-          'Got it. Standup scheduled for '+timeHelper.getDisplayFormat(time)+' eastern'
+          'Got it. Standup scheduled for '+timeHelper.getDisplayFormat(time)
         );
       });
     } else {

--- a/lib/bot/getReportRunner.js
+++ b/lib/bot/getReportRunner.js
@@ -8,7 +8,7 @@ var helpers = require('../helpers');
 var fedHolidays = require('@18f/us-federal-holidays');
 
 function runReports(anytimeBot) {
-  var time = helpers.time.getCurrentUTCTime();
+  var time = helpers.time.getScheduleFormat();
   var date = moment().format('YYYY-MM-DD');
 
   // Don't run if today is a federal holiday

--- a/lib/bot/getUserStandupInfo.js
+++ b/lib/bot/getUserStandupInfo.js
@@ -75,9 +75,10 @@ function getUserStandupInfo(bot, message) {
           if(time.length < 4) {
             time = '0' + time;
           }
+          time = moment.utc(time, 'HHmm');
 
           bot.reply(message, 'Thanks! Your standup for <#'+standupChannel+'> is recorded and will be reported at ' +
-            timeHelper.getDisplayFormat(moment(time, 'HHmm')) +
+            timeHelper.getDisplayFormat(time) +
             '.  It will look like:' + localReport);
         });
       } else {

--- a/lib/helpers/time.js
+++ b/lib/helpers/time.js
@@ -1,39 +1,16 @@
 'use strict';
 
-var moment = require('moment');
-
-function getFourDigitTime(time) {
-  time = String(time);
-  while(time.length < 4) {
-    time = '0' + time;
-  }
-  return time;
-}
-
-function getUTCTimeAssumingEastern(baseTime) {
-  baseTime = baseTime.substr(0, 2) + ':' + baseTime.substr(2);
-  var now = new Date();
-
-  // Use the current date, and append the time.  Let Javascript figure
-  // out the correct UTC time from that, taking dates and junk into account.
-  var parseableString = (now.getUTCMonth() + 1) + '/' + now.getUTCDate() + '/' + now.getUTCFullYear() + ' ' + baseTime + ' EST';
-  var easternTime = new Date(Date.parse(parseableString));
-  var utcTime = (easternTime.getUTCHours() * 100) + easternTime.getUTCMinutes();
-
-  return getFourDigitTime(utcTime);
-}
-
-function getCurrentUTCTime() {
-  var now = new Date();
-  return getFourDigitTime(String(now.getUTCHours()) + String(now.getUTCMinutes()));
-}
+var moment = require('moment-timezone');
+var timezone = 'America/New_York';
 
 function getTimeFromString(str) {
   var time = str.match(/((\d+|:)*(\s)?((a|p)m)|\d{4})/gi);
   if(time) {
-    time = moment(time[0], ['h:mm a','hmm a','hmma','HHmm','hha','hh a']);
+    // Assume incoming strings are in the standard timezone
+    time = moment.tz(time[0], ['h:mm a','hmm a','hmma','HHmm','hha','hh a'], timezone);
     if(time.isValid()) {
-      return time;
+      // But return everything in UTC
+      return moment.utc(time);
     }
   }
   return '';
@@ -41,30 +18,29 @@ function getTimeFromString(str) {
 
 function getScheduleFormat(time) {
   if(!time) {
-    time = new Date();
+    time = moment();
   }
-  return moment(time).format('HHmm');
+  return moment.utc(time).format('HHmm');
 }
 
 function getReportFormat(time) {
   if(!time) {
-    time = new Date();
+    time = moment();
   }
-  return moment(time).format('YYYY-MM-DD');
+  return moment.tz(time, timezone).format('YYYY-MM-DD');
 }
 
 function getDisplayFormat(time) {
   if(!time) {
-    time = new Date();
+    time = moment();
   }
-  return moment(time).format('h:mm a');
+  // Display in the standard timezone
+  return moment.tz(time, timezone).format('h:mm a z');
 }
 
 module.exports = {
   getTimeFromString: getTimeFromString,
   getScheduleFormat: getScheduleFormat,
   getDisplayFormat: getDisplayFormat,
-  getReportFormat: getReportFormat,
-  getCurrentUTCTime: getCurrentUTCTime,
-  getUTCTimeAssumingEastern: getUTCTimeAssumingEastern
+  getReportFormat: getReportFormat
 };

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "botkit": "0.0.5",
     "dotenv": "^2.0.0",
     "moment": "^2.11.2",
+    "moment-timezone": "^0.5.1",
     "node-schedule": "^1.0.0",
     "pg": "^4.4.4",
     "pg-hstore": "^2.3.2",


### PR DESCRIPTION
Throw out all my crufty timezone code, use a well-maintained plugin for moment instead.  Normalizes on UTC except for display purposes.

Adds the timezone short name (e.g., EST, EDT) to the `getDisplayFormat` method, which addresses #28.
