### PR TITLE
Allow standups from iOS

### DIFF
--- a/features/steps/send-standup.js
+++ b/features/steps/send-standup.js
@@ -35,6 +35,7 @@ module.exports = function() {
         '<#' + _message.channel + '> ' + message, // whole message
         '', // optionally the word 'standup'
         _message.channel,
+        '', // iOS channel tag has '|channelName' on the end
         message
       ];
 

--- a/lib/bot/getUserStandupInfo.js
+++ b/lib/bot/getUserStandupInfo.js
@@ -7,7 +7,7 @@ var models = require('../../models');
 
 function getUserStandupInfo(bot, message) {
   var standupChannel = message.match[2];
-  var content = message.match[3];
+  var content = message.match[4];
   var localReport = '';
   log.verbose('Got user standup info:\n' + message.match[0]);
 
@@ -101,7 +101,7 @@ function attachListener(controller) {
   // TODO: allow multiple ways to separate messages (i.e. \n or ; or |)
   // TODO: update reports when edited
   // TODO: parse standup messages
-  controller.hears(['(standup )?<#(\\S*)>((.|\n)*)'],['direct_message'], getUserStandupInfo);
+  controller.hears(['(standup )?<#(\\S*?)(\\|\\S*)?>((.|\n)*)'],['direct_message'], getUserStandupInfo);
   log.verbose('Attached');
 }
 


### PR DESCRIPTION
Mobile clients don't send channel links the same as desktop clients, because _reasons_.  This accounts for the difference in receiving standups in a DM.  However, mobile clients still don't display links to user correctly in the standup report.  I cannot figure out how to make that work - it may be an issue with attachments display on mobile?
