### PR TITLE
Update tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,8 @@ language: node_js
 node_js:
   - "0.12"
   - "4.4"
-  - "5.8"
+  - "5.11"
+  - "6.0"
 env:
   global:
   - CF_USERNAME=18f-acq_deployer

--- a/features/start-dm-emoji.feature
+++ b/features/start-dm-emoji.feature
@@ -11,4 +11,4 @@ Feature: Start a DM convo when user emoji-reacts to reminder message
     Examples:
       | on-time | response     |
       | is      | Hey there!   |
-      | is not  | Sorry,       |
+      | is not  | Hey there!   |

--- a/features/steps/common.js
+++ b/features/steps/common.js
@@ -12,7 +12,7 @@ module.exports = function() {
       startPrivateConversation: sinon.spy(),
       api: {
         users: {
-          info: sinon.stub().resolves({ real_name: 'Bob the Tester' })
+          info: sinon.stub().yields(null, { user: { real_name: 'Bob the Tester', profile: { image_72: 'thumbnail.png' }}})
         }
       }
     };

--- a/features/steps/common.js
+++ b/features/steps/common.js
@@ -13,6 +13,9 @@ module.exports = function() {
       api: {
         users: {
           info: sinon.stub().yields(null, { user: { real_name: 'Bob the Tester', profile: { image_72: 'thumbnail.png' }}})
+        },
+        team: {
+          info: sinon.stub().yields(null, { team: { name: 'CSomethingSaySomething' }})
         }
       }
     };

--- a/features/steps/run-reminder.js
+++ b/features/steps/run-reminder.js
@@ -14,6 +14,7 @@ module.exports = function() {
   this.When('the reminder time comes', function() {
     _findAllChannelsStub = sinon.stub(models.Channel, 'findAll').resolves([{
       name: 'Test Channel',
+      audience: null
     }]);
 
     // Also stub the bot

--- a/features/steps/run-report.js
+++ b/features/steps/run-report.js
@@ -49,9 +49,9 @@ module.exports = function() {
     common.wait(function() {
       return _findAllChannelsStub.called && _findAllChannelsStub.called && _bot.say.called;
     }, function() {
-      // If the bot sent text and attachments, it tried to
+      // If the bot sent attachments, it tried to
       // report correctly.
-      if(_bot.say.args[0][0].text && _bot.say.args[0][0].attachments.length) {
+      if(_bot.say.args[0][0].attachments.length) {
         done();
       } else {
         done(new Error('Expected bot to report with text and attachments'));

--- a/features/steps/run-report.js
+++ b/features/steps/run-report.js
@@ -17,7 +17,8 @@ module.exports = function() {
     // about database contents.
     _findAllChannelsStub = sinon.stub(models.Channel, 'findAll');
     _findAllChannelsStub.resolves([{
-      name: 'Test Channel'
+      name: 'Test Channel',
+      audience: null
     }]);
 
     _findAllStandupsStub = sinon.stub(models.Standup, 'findAll');

--- a/features/steps/send-standup.js
+++ b/features/steps/send-standup.js
@@ -25,7 +25,7 @@ module.exports = function() {
   this.Given(/^the channel (.+) have a standup/, function(status) {
     if(status === 'does') {
       _findOneChannelStub = sinon.stub(models.Channel, 'findOne').resolves({
-        time: '130', name: 'CSomethingSaySomething'
+        time: '130', name: 'CSomethingSaySomething', audience: null
       });
       _findOrCreateStub = sinon.stub(models.Standup, 'findOrCreate').resolves({ });
       _findOneStandupStub = sinon.stub(models.Standup, 'findOne').resolves({

--- a/features/steps/start-dm-emoji.js
+++ b/features/steps/start-dm-emoji.js
@@ -38,7 +38,7 @@ module.exports = function() {
     _message.user = 'U7654321';
     _message.reaction = 'thumbsup';
 
-    _findOneChannelStub = sinon.stub(models.Channel, 'findOne').resolves({ time: '1230', channel: _message.item.channel });
+    _findOneChannelStub = sinon.stub(models.Channel, 'findOne').resolves({ time: '1230', name: _message.item.channel, audience: null });
     common.botStartsConvoWith(_message, common.botController.on, done);
   });
 


### PR DESCRIPTION
Updates a few things in the tests to return the expected mocked data
- Slack user API mock should return a user name and avatar
- Need to mock the Slack team API
- Queries for channels should return the `audience` property (used null for tests)
- Bot reports are just attachments now and don't include the `text` property at all
