### PR TITLE
58 edit interview responses

### DIFF
--- a/features/edit-interview.feature
+++ b/features/edit-interview.feature
@@ -1,0 +1,31 @@
+Feature: Send standup to the bot
+
+  Scenario: I try to edit a standup
+    Given the bot is running
+    And I want to send a standup for a public channel
+    And the channel does have a standup
+    And I have previous standups
+    When I DM the bot with valid standup edit
+    Then the bot should start a private message with ":thumbsup: You bet!"
+
+  Scenario: I try to edit a standup without an existing standup
+    Given the bot is running
+    And I want to send a standup for a public channel
+    And the channel does have a standup
+    And I do not have previous standups
+    When I DM the bot with valid standup edit
+    Then the bot should start a private message with ":thinking_face: It seems"
+
+  Scenario Outline: I try to edit a standup in an invalid manner
+    Given the bot is running
+    And I want to send a standup for a <visibility> channel
+    And the channel <status> have a standup
+    And I have previous standups
+    When I DM the bot with invalid standup edit
+    Then the bot should respond "<response>"
+
+    Examples:
+      | visibility | status   | response |
+      | public     | does not | channel doesn't have any standups set |
+      | private    | does     | only work with public channels |
+      | private    | does not | only work with public channels |

--- a/features/steps/common.js
+++ b/features/steps/common.js
@@ -1,5 +1,6 @@
 'use strict';
 var sinon = require('sinon');
+var models = require('../../models');
 
 module.exports = function() {
   this.Given('the bot is running', function() {
@@ -59,12 +60,48 @@ module.exports = function() {
 
     var DmReply = module.exports.botController.on.__bot.startPrivateConversation.args[0][1];
     DmReply('nothing', convo);
-    DmReply = convo.say.args[0][0];
-    console.log(DmReply);
+
+    var botResponse = convo.say.called ? convo.say : convo.ask;
+    DmReply = botResponse.args[0][0];
     if(DmReply.indexOf(responseContains) >= 0) {
       return true;
     } else {
       throw new Error('Bot reply did not contain "' + responseContains + '"');
+    }
+  });
+
+  var _standupFindStub;
+  this.Given(/I( do not)? have previous standups/, function(dont) {
+    var todayDate = new Date();
+    var yesterdayDate = new Date(new Date() - 24 * 60 * 60 * 1000);
+
+    _standupFindStub = sinon.stub(models.Standup, 'findAll');
+    if(dont) {
+      _standupFindStub.resolves([ ]);
+    } else {
+      _standupFindStub.resolves([
+        {
+          date: todayDate.toISOString(),
+          yesterday: 'Did a thing',
+          today: 'Doing a thing',
+          blockers: 'Nothing',
+          goals: 'Something'
+        },
+        {
+          date: yesterdayDate.toISOString(),
+          yesterday: 'Did a different thing',
+          today: 'Doing another thing',
+          blockers: 'Something',
+          goals: 'Everything'
+        }
+      ]);
+    }
+  });
+
+  this.After(function() {
+    if(_standupFindStub) {
+      _standupFindStub.restore();
+      _standupFindStub = null;
     }
   });
 };

--- a/features/steps/common.js
+++ b/features/steps/common.js
@@ -12,6 +12,10 @@ module.exports = function() {
       reply: sinon.spy(),
       startPrivateConversation: sinon.spy(),
       say: sinon.spy(),
+      utterances: {
+        yes: '',
+        no: ''
+      },
       api: {
         users: {
           info: sinon.stub().yields(null, { user: { real_name: 'Bob the Tester', profile: { image_72: 'thumbnail.png' }}})

--- a/features/steps/send-standup.js
+++ b/features/steps/send-standup.js
@@ -58,6 +58,25 @@ module.exports = function() {
       common.botRepliesToHearing(_message, done);
   });
 
+  this.When(/^I DM the bot with (valid|invalid) standup edit$/, function(valid, done) {
+      botLib.getUserStandupInfo(common.botController);
+
+      _message.user = 'U7654321';
+      _message.match = [
+        '<#' + _message.channel + '> edit today',
+        '', // optionally the word 'standup'
+        _message.channel,
+        '', // iOS channel tag has '|channelName' on the end
+        'edit today'
+      ];
+
+      if(valid === 'valid') {
+        common.botStartsConvoWith(_message, common.botController.hears, done);
+      } else {
+        common.botRepliesToHearing(_message, done);
+      }
+  });
+
   this.When('I edit a DM to the bot to say', function(message, done) {
     botLib.getUserStandupInfo(common.botController);
     // _getUserStub = sinon.stub(helpers, 'getUser').resolves({ real_name: 'Bob the Tester' });

--- a/features/steps/start-dm-emoji.js
+++ b/features/steps/start-dm-emoji.js
@@ -11,6 +11,7 @@ module.exports = function() {
   var now;
   _message.item = { };
   var _getTimeStub;
+  var _findAllStandupsStub;
   var _findOneChannelStub;
   var _botId = '';
 
@@ -38,6 +39,7 @@ module.exports = function() {
     _message.user = 'U7654321';
     _message.reaction = 'thumbsup';
 
+    _findAllStandupsStub = sinon.stub(models.Standup, 'findAll').resolves([ ]);
     _findOneChannelStub = sinon.stub(models.Channel, 'findOne').resolves({ time: '1230', name: _message.item.channel, audience: null });
     common.botStartsConvoWith(_message, common.botController.on, done);
   });
@@ -46,6 +48,10 @@ module.exports = function() {
     if(_findOneChannelStub) {
       _findOneChannelStub.restore();
       _findOneChannelStub = null;
+    }
+    if(_findAllStandupsStub) {
+      _findAllStandupsStub.restore();
+      _findAllStandupsStub = null;
     }
     if(_getTimeStub) {
       _getTimeStub.stub.restore();

--- a/features/steps/user-report.js
+++ b/features/steps/user-report.js
@@ -10,28 +10,6 @@ module.exports = function () {
   var _standupFindStub = null;
   var _message = { };
 
-  this.Given('I have previous standups', function() {
-    var todayDate = new Date();
-    var yesterdayDate = new Date(new Date() - 24 * 60 * 60 * 1000);
-
-    _standupFindStub = sinon.stub(models.Standup, 'findAll').resolves([
-      {
-        date: todayDate.toISOString(),
-        yesterday: 'Did a thing',
-        today: 'Doing a thing',
-        blockers: 'Nothing',
-        goals: 'Something'
-      },
-      {
-        date: yesterdayDate.toISOString(),
-        yesterday: 'Did a different thing',
-        today: 'Doing another thing',
-        blockers: 'Something',
-        goals: 'Everything'
-      }
-    ]);
-  });
-
   this.When(/I say "@bot ((report) (.*))"/, function(message, triggerWord, rest, done) {
     botLib.userReport(common.botController);
 
@@ -46,12 +24,5 @@ module.exports = function () {
     ];
 
     common.botRepliesToHearing(_message, done);
-  });
-
-  this.After(function() {
-    if(_standupFindStub) {
-      _standupFindStub.restore();
-      _standupFindStub = null;
-    }
   });
 };

--- a/lib/bot/getUserStandupInfo.js
+++ b/lib/bot/getUserStandupInfo.js
@@ -8,11 +8,19 @@ var models = require('../../models');
 function getUserStandupInfo(bot, message) {
   var standupChannel = message.match[2];
   var content = message.match[4];
+  var section;
+  var sectionMatch = content ? content.match(/edit\s+(yesterday|today|blockers|goal)/i) : false;
+
+  if(sectionMatch) {
+    section = sectionMatch[1].toLowerCase();
+    content = '';
+  }
+
   if (standupChannel[0] === 'C'){
     if (content.length > 0) {
       helpers.doBlock(bot, message, standupChannel, message.user);
     } else {
-      helpers.doInterview(bot, standupChannel, message.user);
+      helpers.doInterview(bot, standupChannel, message.user, section);
     }
   } else {
     log.warn('Channel is not public');

--- a/lib/bot/getUserStandupInfo.js
+++ b/lib/bot/getUserStandupInfo.js
@@ -17,11 +17,24 @@ function getUserStandupInfo(bot, message) {
   }
 
   if (standupChannel[0] === 'C'){
-    if (content.length > 0) {
-      helpers.doBlock(bot, message, standupChannel, message.user);
-    } else {
-      helpers.doInterview(bot, standupChannel, message.user, section);
-    }
+    models.Channel.findOne({
+      where: {
+        name: standupChannel
+      }
+    }).then(function (channel) {
+      if(channel) {
+        if (content.length > 0) {
+          helpers.doBlock(bot, message, standupChannel, message.user);
+        } else {
+          helpers.doInterview(bot, standupChannel, message.user, section);
+        }
+      } else {
+        log.info('Channel doesn\'t have a standup scheduled');
+        bot.reply(message,
+          'The <#'+standupChannel+'> channel doesn\'t have any standups set'
+        );
+      }
+    });
   } else {
     log.warn('Channel is not public');
     bot.reply(message, 'I can only work with public channels. Sorry!');

--- a/lib/helpers/doBlock.js
+++ b/lib/helpers/doBlock.js
@@ -112,11 +112,6 @@ module.exports = function doBlock(bot, message, blockChannel, blockUser) {
           });
         });
       });
-    } else {
-      log.info('Channel doesn\'t have a standup scheduled');
-      bot.reply(message,
-        'The <#'+blockChannel+'> channel doesn\'t have any standups set'
-      );
     }
   });
 };

--- a/lib/helpers/doInterview.js
+++ b/lib/helpers/doInterview.js
@@ -7,9 +7,9 @@ var timeHelper = require('./time');
 var standupHelper = require('./getStandupReport');
 var reportHelper = require('./doChannelReport');
 
-module.exports = function doInterview(bot, interviewChannel, interviewUser) {
-  log.verbose('Starting an interview with '+interviewUser);
-  console.log(interviewChannel);
+module.exports = function doInterview(bot, interviewChannel, interviewUser, singleSection) {
+  log.verbose('Starting an interview with '+interviewUser+' for channel ' + interviewChannel);
+
   models.Channel.findOne({
     where: {
       name: interviewChannel
@@ -23,10 +23,12 @@ module.exports = function doInterview(bot, interviewChannel, interviewUser) {
       var userRealName;
       var thumbUrl;
       var pastBlockers = '';
+
       bot.api.users.info({'user':interviewUser}, function(err, response) {
         userRealName = response.user.real_name;
         thumbUrl = response.user.profile.image_72;
       });
+
       models.Standup.findAll({
         where: {
           user: interviewUser,
@@ -34,7 +36,8 @@ module.exports = function doInterview(bot, interviewChannel, interviewUser) {
           createdAt: {
             $gt: new Date(new Date() - 7 * 24 * 60 * 60 * 1000)
           }
-        }
+        },
+        order: [[ 'createdAt', 'DESC' ]]
       }).then(function (standups) {
         if (standups.length > 0) {
           pastBlockers += ' Recent blockers were:';
@@ -42,126 +45,147 @@ module.exports = function doInterview(bot, interviewChannel, interviewUser) {
         for (var s in standups) {
           pastBlockers += '\n> '+standups[s].blockers;
         }
-      });
-      bot.startPrivateConversation({user: interviewUser}, function(response, convo){
-        // TODO: consider allowing multi-line responses
-        convo.say('Hey there! Let\'s record your standup for <#'+interviewChannel+'>'+
-          ' (Say "skip" to skip any of the questions):');
-        convo.ask('What did you do yesterday?', function(response, conversation) {
-          if (!response.text.match(/^skip$/ig)) {
-            yesterday = response.text;
-          } else {
-            yesterday = null;
-          }
-          conversation.next();
-        });
-        convo.ask('What are you doing today? (Use :pager: if you\'re available'+
-        ' for projects)', function(response, conversation) {
-          if (!response.text.match(/^skip$/ig)) {
-            today = response.text;
-          } else {
-            today = null;
-          }
-          conversation.next();
-        });
-        convo.ask('What are your blockers?'+pastBlockers, function(response, conversation) {
-          if (!response.text.match(/^skip$/ig)) {
-            blockers= response.text;
-          } else {
-            blockers= null;
-          }
-          conversation.next();
-        });
-        convo.ask('Any major goal for the day?', function(response, conversation) {
-          if (!response.text.match(/^skip$/ig)) {
-            goal = response.text;
-          } else {
-            goal = null;
-          }
-          conversation.next();
-        });
-        convo.on('end',function(convo) {
 
-          if (convo.status === 'completed') {
-            // botkit provides a cool function to get all responses, but it was easier
-            // to just set them during the convo
-            // var res = convo.extractResponses();
+        bot.startPrivateConversation({user: interviewUser}, function(response, convo){
+          // TODO: consider allowing multi-line responses
+          if(singleSection) {
+            // Need to make sure the user already has a standup recorded for today.
+            // If not, prompt them to do it.
+            convo.say(':thumbsup: You bet!  Let\'s update the '+singleSection+' portion of your'+
+              ' standup for <#'+interviewChannel+'>\nYour previous response was:\n>'+
+              standups[0][singleSection]);
+          } else {
+            convo.say('Hey there! Let\'s record your standup for <#'+interviewChannel+'>'+
+              ' (Say "skip" to skip any of the questions):');
+          }
 
-            models.Standup.findOrCreate({
-              where: {
-                channel: interviewChannel,
-                date: timeHelper.getReportFormat(),
-                user: interviewUser
+          if(!singleSection || singleSection === 'yesterday') {
+            convo.ask('What did you do yesterday?', function(response, conversation) {
+              if (!response.text.match(/^skip$/ig)) {
+                yesterday = response.text;
+              } else {
+                yesterday = null;
               }
-            }).then(function (standup) {
-              if (!yesterday) {
-                yesterday = standup.yesterday;
-              }
-              if (!today) {
-                today = standup.today;
-              }
-              if (!blockers) {
-                blockers = standup.blockers;
-              }
-              if (!goal) {
-                goal = standup.goal;
-              }
+              conversation.next();
+            });
+          }
 
-              models.Standup.update(
-                {
-                  yesterday: yesterday,
-                  today: today,
-                  blockers: blockers,
-                  goal: goal,
-                  userRealName: userRealName,
-                  thumbUrl: thumbUrl
-                },
-                {
-                  where: {
-                    channel: interviewChannel,
-                    date: timeHelper.getReportFormat(),
-                    user: interviewUser
-                  }
+          if(!singleSection || singleSection === 'today') {
+            convo.ask('What are you doing today? (Use :pager: if you\'re available'+
+            ' for projects)', function(response, conversation) {
+              if (!response.text.match(/^skip$/ig)) {
+                today = response.text;
+              } else {
+                today = null;
+              }
+              conversation.next();
+            });
+          }
+
+          if(!singleSection || singleSection === 'blockers') {
+            convo.ask('What are your blockers?'+pastBlockers, function(response, conversation) {
+              if (!response.text.match(/^skip$/ig)) {
+                blockers = response.text;
+              } else {
+                blockers= null;
+              }
+              conversation.next();
+            });
+          }
+
+          if(!singleSection || singleSection === 'goal') {
+            convo.ask('Any major goal for the day?', function(response, conversation) {
+              if (!response.text.match(/^skip$/ig)) {
+                goal = response.text;
+              } else {
+                goal = null;
+              }
+              conversation.next();
+            });
+          }
+          convo.on('end',function(convo) {
+
+            if (convo.status === 'completed') {
+              // botkit provides a cool function to get all responses, but it was easier
+              // to just set them during the convo
+              // var res = convo.extractResponses();
+
+              models.Standup.findOrCreate({
+                where: {
+                  channel: interviewChannel,
+                  date: timeHelper.getReportFormat(),
+                  user: interviewUser
                 }
-              ).then(function () {
-                var latestReport = '';
-                models.Channel.findOne({
-                  where: {
-                    name: interviewChannel
+              }).then(function (standup) {
+                if (!yesterday) {
+                  yesterday = standup.yesterday;
+                }
+                if (!today) {
+                  today = standup.today;
+                }
+                if (!blockers) {
+                  blockers = standup.blockers;
+                }
+                if (!goal) {
+                  goal = standup.goal;
+                }
+
+                models.Standup.update(
+                  {
+                    yesterday: yesterday,
+                    today: today,
+                    blockers: blockers,
+                    goal: goal,
+                    userRealName: userRealName,
+                    thumbUrl: thumbUrl
+                  },
+                  {
+                    where: {
+                      channel: interviewChannel,
+                      date: timeHelper.getReportFormat(),
+                      user: interviewUser
+                    }
                   }
-                }).then(function(channel) {
-                  latestReport = channel.latestReport;
-                });
-                models.Standup.findOne({
-                  where: {
-                    channel: interviewChannel,
-                    date: timeHelper.getReportFormat(),
-                    user: interviewUser
-                  }
-                }).then(function(standup) {
-                  var now = timeHelper.getDisplayFormat();
-                  var channelTime = timeHelper.getDisplayFormat(channel.time);
-                  if (moment(now, 'hh:mm a Z').isBefore(moment(channelTime, 'hh:mm a Z'))) {
-                    log.verbose('Standup info recorded for ' + userRealName);
-                    bot.startPrivateConversation({user: interviewUser}, function(response, convo){
-                      convo.say({
-                        text: 'Thanks! Your standup for <#'+interviewChannel+
-                        '> is recorded and will be reported at ' +
-                        timeHelper.getDisplayFormat(channel.time) +
-                        '.  It will look like:',
-                        attachments: [ standupHelper(standup) ]
+                ).then(function () {
+                  var latestReport = '';
+                  models.Channel.findOne({
+                    where: {
+                      name: interviewChannel
+                    }
+                  }).then(function(channel) {
+                    latestReport = channel.latestReport;
+                  });
+                  models.Standup.findOne({
+                    where: {
+                      channel: interviewChannel,
+                      date: timeHelper.getReportFormat(),
+                      user: interviewUser
+                    }
+                  }).then(function(standup) {
+                    var now = timeHelper.getDisplayFormat();
+                    var channelTime = timeHelper.getDisplayFormat(channel.time);
+                    if (moment(now, 'hh:mm a Z').isBefore(moment(channelTime, 'hh:mm a Z'))) {
+                      log.verbose('Standup info recorded for ' + userRealName);
+                      bot.startPrivateConversation({user: interviewUser}, function(response, convo){
+                        convo.say({
+                          text: 'Thanks! Your standup for <#'+interviewChannel+
+                          '> is recorded and will be reported at ' +
+                          timeHelper.getDisplayFormat(channel.time) +
+                          '.  It will look like:',
+                          attachments: [ standupHelper(standup) ]
+                        });
                       });
-                    });
-                  } else {
-                    log.verbose('Late report from '+userRealName+'; updating previous report');
-                    reportHelper(bot, interviewChannel, true, userRealName);
-                  }
+                    } else {
+                      log.verbose('Late report from '+userRealName+'; updating previous report');
+                      reportHelper(bot, interviewChannel, true, userRealName);
+                    }
+                  });
                 });
               });
-            });
-          } else {
-            // something happened that caused the conversation to stop prematurely
-          }
+            } else {
+              // something happened that caused the conversation to stop prematurely
+            }
+          });
         });
       });
     }

--- a/lib/helpers/doInterview.js
+++ b/lib/helpers/doInterview.js
@@ -50,26 +50,32 @@ module.exports = function doInterview(bot, interviewChannel, interviewUser, sing
           // TODO: consider allowing multi-line responses
           var interviewSetup = new Promise(function(resolve, reject) {
             if(singleSection) {
-              if(standups.length && true) {
-                // Need to make sure the user already has a standup recorded for today.
-                // If not, prompt them to do it.
+              // Need to make sure the user already has a standup recorded for today.
+              // If not, prompt them to do it because there's nothing to edit.
+              if(standups.length && timeHelper.datesAreSameDay(standups[0].createdAt, new Date())) {
                 convo.say(':thumbsup: You bet!  Let\'s update the '+singleSection+' portion of your'+
                   ' standup for <#'+interviewChannel+'>\nYour previous response was:\n>'+
                   standups[0][singleSection]);
                 resolve();
               } else {
                 convo.ask(':thinking_face: It seems you haven\'t recorded a standup for today yet.'+
-                  ' Would you like to do that now?', function(response, conversation) {
-                    if(response.text.match(/\b(y|yes|yep|yeah|ok|okay|sure)\b/i)) {
-                      singleSection = false;
-                      conversation.next();
-                      resolve();
-                    } else {
-                      conversation.say('Okay!  Maybe later.  :simple_smile:');
-                      conversation.next();
-                      reject();
+                  ' Would you like to do that now?', [
+                    {
+                      pattern: bot.utterances.yes,
+                      callback: function(_, c) {
+                        c.next();
+                        resolve();
+                      }
+                    },
+                    {
+                      default: true,
+                      callback: function(_, c) {
+                        c.say('Okay! Maybe later. :simple_smile:');
+                        c.next();
+                        reject();
+                      }
                     }
-                  });
+                  ]);
               }
             } else {
               convo.say('Hey there! Let\'s record your standup for <#'+interviewChannel+'>'+

--- a/lib/helpers/doInterview.js
+++ b/lib/helpers/doInterview.js
@@ -38,153 +38,180 @@ module.exports = function doInterview(bot, interviewChannel, interviewUser, sing
           }
         },
         order: [[ 'createdAt', 'DESC' ]]
-      }).then(function (standups) {
+      }).then(function (standups, e) {
         if (standups.length > 0) {
           pastBlockers += ' Recent blockers were:';
-        }
-        for (var s in standups) {
-          pastBlockers += '\n> '+standups[s].blockers;
+          for (var s in standups) {
+            pastBlockers += '\n> '+standups[s].blockers;
+          }
         }
 
         bot.startPrivateConversation({user: interviewUser}, function(response, convo){
           // TODO: consider allowing multi-line responses
-          if(singleSection) {
-            // Need to make sure the user already has a standup recorded for today.
-            // If not, prompt them to do it.
-            convo.say(':thumbsup: You bet!  Let\'s update the '+singleSection+' portion of your'+
-              ' standup for <#'+interviewChannel+'>\nYour previous response was:\n>'+
-              standups[0][singleSection]);
-          } else {
-            convo.say('Hey there! Let\'s record your standup for <#'+interviewChannel+'>'+
-              ' (Say "skip" to skip any of the questions):');
-          }
-
-          if(!singleSection || singleSection === 'yesterday') {
-            convo.ask('What did you do yesterday?', function(response, conversation) {
-              if (!response.text.match(/^skip$/ig)) {
-                yesterday = response.text;
+          var interviewSetup = new Promise(function(resolve, reject) {
+            if(singleSection) {
+              if(standups.length && true) {
+                // Need to make sure the user already has a standup recorded for today.
+                // If not, prompt them to do it.
+                convo.say(':thumbsup: You bet!  Let\'s update the '+singleSection+' portion of your'+
+                  ' standup for <#'+interviewChannel+'>\nYour previous response was:\n>'+
+                  standups[0][singleSection]);
+                resolve();
               } else {
-                yesterday = null;
-              }
-              conversation.next();
-            });
-          }
-
-          if(!singleSection || singleSection === 'today') {
-            convo.ask('What are you doing today? (Use :pager: if you\'re available'+
-            ' for projects)', function(response, conversation) {
-              if (!response.text.match(/^skip$/ig)) {
-                today = response.text;
-              } else {
-                today = null;
-              }
-              conversation.next();
-            });
-          }
-
-          if(!singleSection || singleSection === 'blockers') {
-            convo.ask('What are your blockers?'+pastBlockers, function(response, conversation) {
-              if (!response.text.match(/^skip$/ig)) {
-                blockers = response.text;
-              } else {
-                blockers= null;
-              }
-              conversation.next();
-            });
-          }
-
-          if(!singleSection || singleSection === 'goal') {
-            convo.ask('Any major goal for the day?', function(response, conversation) {
-              if (!response.text.match(/^skip$/ig)) {
-                goal = response.text;
-              } else {
-                goal = null;
-              }
-              conversation.next();
-            });
-          }
-          convo.on('end',function(convo) {
-
-            if (convo.status === 'completed') {
-              // botkit provides a cool function to get all responses, but it was easier
-              // to just set them during the convo
-              // var res = convo.extractResponses();
-
-              models.Standup.findOrCreate({
-                where: {
-                  channel: interviewChannel,
-                  date: timeHelper.getReportFormat(),
-                  user: interviewUser
-                }
-              }).then(function (standup) {
-                if (!yesterday) {
-                  yesterday = standup.yesterday;
-                }
-                if (!today) {
-                  today = standup.today;
-                }
-                if (!blockers) {
-                  blockers = standup.blockers;
-                }
-                if (!goal) {
-                  goal = standup.goal;
-                }
-
-                models.Standup.update(
-                  {
-                    yesterday: yesterday,
-                    today: today,
-                    blockers: blockers,
-                    goal: goal,
-                    userRealName: userRealName,
-                    thumbUrl: thumbUrl
-                  },
-                  {
-                    where: {
-                      channel: interviewChannel,
-                      date: timeHelper.getReportFormat(),
-                      user: interviewUser
-                    }
-                  }
-                ).then(function () {
-                  var latestReport = '';
-                  models.Channel.findOne({
-                    where: {
-                      name: interviewChannel
-                    }
-                  }).then(function(channel) {
-                    latestReport = channel.latestReport;
-                  });
-                  models.Standup.findOne({
-                    where: {
-                      channel: interviewChannel,
-                      date: timeHelper.getReportFormat(),
-                      user: interviewUser
-                    }
-                  }).then(function(standup) {
-                    var now = timeHelper.getDisplayFormat();
-                    var channelTime = timeHelper.getDisplayFormat(channel.time);
-                    if (moment(now, 'hh:mm a Z').isBefore(moment(channelTime, 'hh:mm a Z'))) {
-                      log.verbose('Standup info recorded for ' + userRealName);
-                      bot.startPrivateConversation({user: interviewUser}, function(response, convo){
-                        convo.say({
-                          text: 'Thanks! Your standup for <#'+interviewChannel+
-                          '> is recorded and will be reported at ' +
-                          timeHelper.getDisplayFormat(channel.time) +
-                          '.  It will look like:',
-                          attachments: [ standupHelper(standup) ]
-                        });
-                      });
+                convo.ask(':thinking_face: It seems you haven\'t recorded a standup for today yet.'+
+                  ' Would you like to do that now?', function(response, conversation) {
+                    if(response.text.match(/\b(y|yes|yep|yeah|ok|okay|sure)\b/i)) {
+                      singleSection = false;
+                      conversation.next();
+                      resolve();
                     } else {
-                      log.verbose('Late report from '+userRealName+'; updating previous report');
-                      reportHelper(bot, interviewChannel, true, userRealName);
+                      conversation.say('Okay!  Maybe later.  :simple_smile:');
+                      conversation.next();
+                      reject();
                     }
+                  });
+              }
+            } else {
+              convo.say('Hey there! Let\'s record your standup for <#'+interviewChannel+'>'+
+                ' (Say "skip" to skip any of the questions):');
+              resolve();
+            }
+          });
+
+          interviewSetup.then(function() {
+            if(!singleSection || singleSection === 'yesterday') {
+              convo.ask('What did you do yesterday?', function(response, conversation) {
+                if (!response.text.match(/^skip$/ig)) {
+                  yesterday = response.text;
+                } else {
+                  yesterday = null;
+                }
+                conversation.next();
+              });
+            }
+
+            if(!singleSection || singleSection === 'today') {
+              convo.ask('What are you doing today? (Use :pager: if you\'re available'+
+              ' for projects)', function(response, conversation) {
+                if (!response.text.match(/^skip$/ig)) {
+                  today = response.text;
+                } else {
+                  today = null;
+                }
+                conversation.next();
+              });
+            }
+
+            if(!singleSection || singleSection === 'blockers') {
+              convo.ask('What are your blockers?'+pastBlockers, function(response, conversation) {
+                if (!response.text.match(/^skip$/ig)) {
+                  blockers = response.text;
+                } else {
+                  blockers= null;
+                }
+                conversation.next();
+              });
+            }
+
+            if(!singleSection || singleSection === 'goal') {
+              convo.ask('Any major goal for the day?', function(response, conversation) {
+                if (!response.text.match(/^skip$/ig)) {
+                  goal = response.text;
+                } else {
+                  goal = null;
+                }
+                conversation.next();
+              });
+            }
+
+            convo.on('end',function(convo) {
+              if (convo.status === 'completed') {
+                // botkit provides a cool function to get all responses, but it was easier
+                // to just set them during the convo
+                // var res = convo.extractResponses();
+
+                models.Standup.findOrCreate({
+                  where: {
+                    channel: interviewChannel,
+                    date: timeHelper.getReportFormat(),
+                    user: interviewUser
+                  }
+                }).then(function (standup) {
+                  if (!yesterday) {
+                    yesterday = standup.yesterday;
+                  }
+                  if (!today) {
+                    today = standup.today;
+                  }
+                  if (!blockers) {
+                    blockers = standup.blockers;
+                  }
+                  if (!goal) {
+                    goal = standup.goal;
+                  }
+
+                  models.Standup.update(
+                    {
+                      yesterday: yesterday,
+                      today: today,
+                      blockers: blockers,
+                      goal: goal,
+                      userRealName: userRealName,
+                      thumbUrl: thumbUrl
+                    },
+                    {
+                      where: {
+                        channel: interviewChannel,
+                        date: timeHelper.getReportFormat(),
+                        user: interviewUser
+                      }
+                    }
+                  ).then(function () {
+                    var latestReport = '';
+                    models.Channel.findOne({
+                      where: {
+                        name: interviewChannel
+                      }
+                    }).then(function(channel) {
+                      latestReport = channel.latestReport;
+                    });
+                    models.Standup.findOne({
+                      where: {
+                        channel: interviewChannel,
+                        date: timeHelper.getReportFormat(),
+                        user: interviewUser
+                      }
+                    }).then(function(standup) {
+                      var now = timeHelper.getDisplayFormat();
+                      var channelTime = timeHelper.getDisplayFormat(channel.time);
+                      if (moment(now, 'hh:mm a Z').isBefore(moment(channelTime, 'hh:mm a Z'))) {
+                        log.verbose('Standup info recorded for ' + userRealName);
+                        bot.startPrivateConversation({user: interviewUser}, function(response, convo){
+                          convo.say({
+                            text: 'Thanks! Your standup for <#'+interviewChannel+
+                            '> is recorded and will be reported at ' +
+                            timeHelper.getDisplayFormat(channel.time) +
+                            '.  It will look like:',
+                            attachments: [ standupHelper(standup) ]
+                          });
+                        });
+                      } else {
+                        log.verbose('Late report from '+userRealName+'; updating previous report');
+                        bot.startPrivateConversation({user: interviewUser}, function(response, convo){
+                          convo.say({
+                            text: 'Thanks! Your standup for <#'+interviewChannel+
+                            '> is recorded and and the existing report will be updated!'
+                          });
+                        });
+                        reportHelper(bot, interviewChannel, true, userRealName);
+                      }
+                    });
                   });
                 });
-              });
-            } else {
-              // something happened that caused the conversation to stop prematurely
-            }
+              } else {
+                // something happened that caused the conversation to stop prematurely
+              }
+            });
           });
         });
       });

--- a/lib/helpers/doInterview.js
+++ b/lib/helpers/doInterview.js
@@ -1,7 +1,5 @@
 'use strict';
 
-// var async = require('async');
-// var _ = require('underscore');
 var log = require('../../getLogger')('interview recorder');
 var models = require('../../models');
 var moment = require('moment');
@@ -24,23 +22,11 @@ module.exports = function doInterview(bot, interviewChannel, interviewUser) {
       var goal;
       var userRealName;
       var thumbUrl;
-      // var teamName;
-      // var audience = channel.audience === null ? '<!here>' : channel.audience;
-      // if (audience.search(/<!/) !== 0) {
-      //   audience = '@'+audience;
-      // }
       var pastBlockers = '';
       bot.api.users.info({'user':interviewUser}, function(err, response) {
         userRealName = response.user.real_name;
         thumbUrl = response.user.profile.image_72;
       });
-      // bot.api.team.info({}, function(err, response) {
-      //   if (err) {
-      //     console.log(err);
-      //   } else {
-      //     teamName = response.team.name;
-      //   }
-      // });
       models.Standup.findAll({
         where: {
           user: interviewUser,

--- a/lib/helpers/time.js
+++ b/lib/helpers/time.js
@@ -68,11 +68,16 @@ function getReminderFormat (time, minutes) {
   return moment(time,'HHmm').subtract(minutes, 'minutes').format('HHmm');
 }
 
+function datesAreSameDay(date1, date2) {
+  return getReportFormat(date1) === getReportFormat(date2);
+}
+
 module.exports = {
   getTimeFromString: getTimeFromString,
   getScheduleFormat: getScheduleFormat,
   getDisplayFormat: getDisplayFormat,
   getReportFormat: getReportFormat,
   getCurrentDate: getCurrentDate,
-  getReminderFormat: getReminderFormat
+  getReminderFormat: getReminderFormat,
+  datesAreSameDay: datesAreSameDay
 };


### PR DESCRIPTION
Allow users to edit interview responses.  Based on this user story:

Scenario: Edit a interview answer

Given a completed interview
And a category that has an answer or not
When the standupper writes standup [channel] edit [category]
Then standup-bot asks the interview question again
And provides the previous answer
And the standupper can provide a new answer
And the new answer is recorded.

![screen shot 2016-05-18 at 3 05 07 pm](https://cloud.githubusercontent.com/assets/1775733/15373187/f08c5510-1d09-11e6-8fd0-2277964b77e4.png)

Also adds a response from the bot when it is updating an existing report, so the user gets some kind of feedback.

![screen shot 2016-05-18 at 3 06 31 pm](https://cloud.githubusercontent.com/assets/1775733/15373221/206fe27e-1d0a-11e6-96ae-2b3e848730f7.png)

Closes #58.
