### PR TITLE
Manually start interviews, and provide an exit mechanism

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 node_modules
 coverage
 cf-ssh.yml
+npm-debug.log

--- a/app.js
+++ b/app.js
@@ -103,7 +103,9 @@ controller.spawn({
       // Add or change a standup message for today in a DM with the bot
       botLib.getUserStandupInfo(controller);
 
-      // DM a user when they react to a reminder DM
+      // DM a user when they ask to be interviewed or
+      // they react to a reminder DM
+      botLib.startInterview(controller);
       botLib.startDmEmoji(controller, identity.id);
 
       // Remove a standup

--- a/features/start-interview.feature
+++ b/features/start-interview.feature
@@ -1,0 +1,14 @@
+Feature: Start a DM convo when user emoji-reacts to reminder message
+
+  Scenario Outline:
+    Given the bot is running
+    And I am in a room with the bot
+    And the bot ID is 'U1234567'
+    And it <on-time> before the standup report has run for the day
+    When I say "@bot interview me"
+    Then the bot should start a private message with "<response>"
+
+    Examples:
+      | on-time | response     |
+      | is      | Hey there!   |
+      | is not  | Hey there!   |

--- a/features/steps/start-interview.js
+++ b/features/steps/start-interview.js
@@ -1,0 +1,37 @@
+'use strict';
+var sinon = require('sinon');
+var models = require('../../models');
+var botLib = require('../../lib/bot');
+var common = require('./common');
+
+module.exports = function() {
+  var _message = { };
+
+  var _findAllStandupsStub;
+  var _findOneChannelStub;
+
+  this.When(/I say "(@bot\b.*\binterview\b.*)"/,
+    function(message, done) {
+      botLib.startInterview(common.botController);
+
+      _message.user = 'U7654321';
+      _message.type = 'message';
+      _message.text = message;
+      _message.channel = _message.channel || 'CSomethingSaySomething';
+
+      _findAllStandupsStub = sinon.stub(models.Standup, 'findAll').resolves([ ]);
+      _findOneChannelStub = sinon.stub(models.Channel, 'findOne').resolves({ time: '1230', name: _message.channel, audience: null });
+      common.botStartsConvoWith(_message, common.botController.hears, done);
+  });
+
+  this.After(function() {
+    if(_findOneChannelStub) {
+      _findOneChannelStub.restore();
+      _findOneChannelStub = null;
+    }
+    if(_findAllStandupsStub) {
+      _findAllStandupsStub.restore();
+      _findAllStandupsStub = null;
+    }
+  });
+};

--- a/lib/bot/index.js
+++ b/lib/bot/index.js
@@ -11,6 +11,7 @@ module.exports = {
   setReminder: require('./setReminder'),
   getReminderRunner: require('./getReminderRunner'),
   startDmEmoji: require('./startDmEmoji'),
+  startInterview: require('./startInterview'),
   removeStandup: require('./removeStandup'),
   setAudience: require('./setAudience'),
   userReport: require('./userReport')

--- a/lib/bot/startInterview.js
+++ b/lib/bot/startInterview.js
@@ -1,0 +1,17 @@
+'use strict';
+
+var log = require('../../getLogger')('start interview');
+var helpers = require('../helpers');
+
+function startDmEmoji(bot, message) {
+  log.verbose('Got request to start an interview from '+message.user);
+  helpers.doInterview(bot, message.channel, message.user);
+}
+
+function attachListener(controller) {
+  controller.hears([/\binterview\b/i],['direct_mention'], function(bot, message) {
+    startDmEmoji(bot, message);
+  });
+}
+
+module.exports = attachListener;

--- a/lib/helpers/doInterview.js
+++ b/lib/helpers/doInterview.js
@@ -54,7 +54,7 @@ module.exports = function doInterview(bot, interviewChannel, interviewUser, sing
               // If not, prompt them to do it because there's nothing to edit.
               if(standups.length && timeHelper.datesAreSameDay(standups[0].createdAt, new Date())) {
                 convo.say(':thumbsup: You bet!  Let\'s update the '+singleSection+' portion of your'+
-                  ' standup for <#'+interviewChannel+'>\nYour previous response was:\n>'+
+                  ' standup for <#'+interviewChannel+'> (Say "exit" to cancel this update)\nYour previous response was:\n>'+
                   standups[0][singleSection]);
                 resolve();
               } else {
@@ -79,59 +79,90 @@ module.exports = function doInterview(bot, interviewChannel, interviewUser, sing
               }
             } else {
               convo.say('Hey there! Let\'s record your standup for <#'+interviewChannel+'>'+
-                ' (Say "skip" to skip any of the questions):');
+                ' (Say "skip" to skip any of the questions or "exit" to stop):');
               resolve();
             }
           });
 
+          // Flag whether the conversation is closed by
+          // user action.
+          var exited = false;
+          var checkForExit = function(response, conversation) {
+            if(response.text.match(/^exit$/i)) {
+              // Clear the conversation queue.  We can call
+              // conversation.stop(), but that will prevent this say
+              // from happening, or we can put conversation.stop()
+              // inside a timeout, but that's a timing guessing game
+              // about how long to wait - too short and the say
+              // won't happen, too long and the next ask will happen.
+              // So...  to heck with time guessing, just clear
+              // the queue of stuff to come.
+              conversation.topics['default'].length = 0;
+              conversation.messages.length = 0;
+              conversation.say('Okay! I won\'t record anything right now. :simple_smile:');
+              conversation.next();
+              exited = true;
+              return true;
+            }
+            return false;
+          }
+
           interviewSetup.then(function() {
             if(!singleSection || singleSection === 'yesterday') {
               convo.ask('What did you do yesterday?', function(response, conversation) {
-                if (!response.text.match(/^skip$/ig)) {
-                  yesterday = response.text;
-                } else {
-                  yesterday = null;
+                if(!checkForExit(response, conversation)) {
+                  if (!response.text.match(/^skip$/ig)) {
+                    yesterday = response.text;
+                  } else {
+                    yesterday = null;
+                  }
+                  conversation.next();
                 }
-                conversation.next();
               });
             }
 
             if(!singleSection || singleSection === 'today') {
               convo.ask('What are you doing today? (Use :pager: if you\'re available'+
               ' for projects)', function(response, conversation) {
-                if (!response.text.match(/^skip$/ig)) {
-                  today = response.text;
-                } else {
-                  today = null;
+                if(!checkForExit(response, conversation)) {
+                  if (!response.text.match(/^skip$/ig)) {
+                    today = response.text;
+                  } else {
+                    today = null;
+                  }
+                  conversation.next();
                 }
-                conversation.next();
               });
             }
 
             if(!singleSection || singleSection === 'blockers') {
               convo.ask('What are your blockers?'+pastBlockers, function(response, conversation) {
-                if (!response.text.match(/^skip$/ig)) {
-                  blockers = response.text;
-                } else {
-                  blockers= null;
+                if(!checkForExit(response, conversation)) {
+                  if (!response.text.match(/^skip$/ig)) {
+                    blockers = response.text;
+                  } else {
+                    blockers= null;
+                  }
+                  conversation.next();
                 }
-                conversation.next();
               });
             }
 
             if(!singleSection || singleSection === 'goal') {
               convo.ask('Any major goal for the day?', function(response, conversation) {
-                if (!response.text.match(/^skip$/ig)) {
-                  goal = response.text;
-                } else {
-                  goal = null;
+                if(!checkForExit(response, conversation)) {
+                  if (!response.text.match(/^skip$/ig)) {
+                    goal = response.text;
+                  } else {
+                    goal = null;
+                  }
+                  conversation.next();
                 }
-                conversation.next();
               });
             }
 
             convo.on('end',function(convo) {
-              if (convo.status === 'completed') {
+              if (!exited && convo.status === 'completed') {
                 // botkit provides a cool function to get all responses, but it was easier
                 // to just set them during the convo
                 // var res = convo.extractResponses();


### PR DESCRIPTION
A message in a channel where the bot lives and a standup is recorded of the form `@standup-bot interview` will trigger the standup interview.  Includes tests.

Saying "exit" to any interview question will let the user know that the standup won't be recorded and stops the conversation.  Does not include tests because we haven't built tests for within conversations yet.

Closes #75 
