### PR TITLE
docker and docker-compose support

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,24 @@
+slackbot:
+  image: node:6
+  entrypoint: /app/entrypoint.sh
+  environment:
+    - DATABASE_URL=postgres://postgres:standup@database/standup
+    - PORT=3000
+    - LOG_LEVEL=10
+  expose:
+    - 3000
+  ports:
+    - 3000
+  working_dir: /app
+  volumes:
+    - ./:/app
+    - /app/node_modules
+  links:
+    - database:database
+database:
+  image: postgres:latest
+  environment:
+    - POSTGRES_DB=standup
+    - POSTGRES_PASSWORD=standup
+  expose:
+    - 5432

--- a/documentation/installation.md
+++ b/documentation/installation.md
@@ -2,6 +2,8 @@
 
 ## Pre-requisites
 
+NOTE: If you are planning to run `standup-slack-bot`  in docker, please refer to the [Docker](#docker) section below.
+
 Before installing standup-bot, you'll need to have access to a:
 
 - PostgreSQL database; and
@@ -29,6 +31,20 @@ LOG_LEVEL    | Numeric value indicating the log level.  10 is verbose, 20 is inf
 ## Running
 
 Once everything is set up, to run standup-bot, simply run `npm start`.
+
+## Docker
+
+To skip all the manual steps above, you can run `standup-slack-bot` in [Docker](https://www.docker.com). The only pre-requisite after [installing docker](https://docs.docker.com/engine/installation/) would be [installing docker-compose](https://docs.docker.com/compose/install/).
+
+Also ensure that your `.env` file has your `SLACK_TOKEN` in it:
+
+    $ echo "SLACK_TOKEN=xoxb-<your slackbot API token>" > .env
+
+only `SLACK_TOKEN` is required in `.env`. The rest of the required env variables are already specified in `docker-compose.yaml`.
+
+Finally, to start with docker-compose:
+
+    $ docker-compose up -d
 
 ## Testing
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+npm install && \
+./wait-for-it.sh -s -q -t 0 database:5432 -- npm start

--- a/wait-for-it.sh
+++ b/wait-for-it.sh
@@ -1,4 +1,6 @@
-#!/bin/bash
+#!/usr/bin/env bash
+#   Use this script to test if a given TCP host/port are available
+
 cmdname=$(basename $0)
 
 echoerr() { if [[ $QUIET -ne 1 ]]; then echo "$@" 1>&2; fi }
@@ -19,6 +21,7 @@ Usage:
 USAGE
     exit 1
 }
+
 wait_for()
 {
     if [[ $TIMEOUT -gt 0 ]]; then
@@ -40,6 +43,7 @@ wait_for()
     done
     return $result
 }
+
 wait_for_wrapper()
 {
     # In order to support SIGINT during timeout: http://unix.stackexchange.com/a/57692
@@ -57,96 +61,106 @@ wait_for_wrapper()
     fi
     return $RESULT
 }
-# process arguments
-while [[ $# -gt 0 ]]
-do
-    case "$1" in
-        *:* )
-        hostport=(${1//:/ })
-        HOST=${hostport[0]}
-        PORT=${hostport[1]}
-        shift 1
-        ;;
-        --child)
-        CHILD=1
-        shift 1
-        ;;
-        -q | --quiet)
-        QUIET=1
-        shift 1
-        ;;
-        -s | --strict)
-        STRICT=1
-        shift 1
-        ;;
-        -h)
-        HOST="$2"
-        if [[ $HOST == "" ]]; then break; fi
-        shift 2
-        ;;
-        --host=*)
-        HOST="${1#*=}"
-        shift 1
-        ;;
-        -p)
-        PORT="$2"
-        if [[ $PORT == "" ]]; then break; fi
-        shift 2
-        ;;
-        --port=*)
-        PORT="${1#*=}"
-        shift 1
-        ;;
-        -t)
-        TIMEOUT="$2"
-        if [[ $TIMEOUT == "" ]]; then break; fi
-        shift 2
-        ;;
-        --timeout=*)
-        TIMEOUT="${1#*=}"
-        shift 1
-        ;;
-        --)
-        shift
-        CLI="$@"
-        break
-        ;;
-        --help)
-        usage
-        ;;
-        *)
-        echoerr "Unknown argument: $1"
-        usage
-        ;;
-    esac
-done
-if [[ "$HOST" == "" || "$PORT" == "" ]]; then
-    echoerr "Error: you need to provide a host and port to test."
-    usage
-fi
-TIMEOUT=${TIMEOUT:-15}
-STRICT=${STRICT:-0}
-CHILD=${CHILD:-0}
-QUIET=${QUIET:-0}
-if [[ $CHILD -gt 0 ]]; then
-    wait_for
-    RESULT=$?
-    exit $RESULT
-else
-    if [[ $TIMEOUT -gt 0 ]]; then
-        wait_for_wrapper
-        RESULT=$?
-    else
-        wait_for
-        RESULT=$?
-    fi
-fi
-if [[ $CLI != "" ]]; then
-    if [[ $RESULT -ne 0 && $STRICT -eq 1 ]]; then
-        echoerr "$cmdname: strict mode, refusing to execute subprocess"
-        exit $RESULT
-    fi
-    exec $CLI
-else
-    exit $RESULT
-fi
+
+main()
+{
+  # process arguments
+  while [[ $# -gt 0 ]]
+  do
+      case "$1" in
+          *:* )
+          hostport=(${1//:/ })
+          HOST=${hostport[0]}
+          PORT=${hostport[1]}
+          shift 1
+          ;;
+          --child)
+          CHILD=1
+          shift 1
+          ;;
+          -q | --quiet)
+          QUIET=1
+          shift 1
+          ;;
+          -s | --strict)
+          STRICT=1
+          shift 1
+          ;;
+          -h)
+          HOST="$2"
+          if [[ $HOST == "" ]]; then break; fi
+          shift 2
+          ;;
+          --host=*)
+          HOST="${1#*=}"
+          shift 1
+          ;;
+          -p)
+          PORT="$2"
+          if [[ $PORT == "" ]]; then break; fi
+          shift 2
+          ;;
+          --port=*)
+          PORT="${1#*=}"
+          shift 1
+          ;;
+          -t)
+          TIMEOUT="$2"
+          if [[ $TIMEOUT == "" ]]; then break; fi
+          shift 2
+          ;;
+          --timeout=*)
+          TIMEOUT="${1#*=}"
+          shift 1
+          ;;
+          --)
+          shift
+          CLI="$@"
+          break
+          ;;
+          --help)
+          usage
+          ;;
+          *)
+          echoerr "Unknown argument: $1"
+          usage
+          ;;
+      esac
+  done
+
+  if [[ "$HOST" == "" || "$PORT" == "" ]]; then
+      echoerr "Error: you need to provide a host and port to test."
+      usage
+  fi
+
+  TIMEOUT=${TIMEOUT:-15}
+  STRICT=${STRICT:-0}
+  CHILD=${CHILD:-0}
+  QUIET=${QUIET:-0}
+
+  if [[ $CHILD -gt 0 ]]; then
+      wait_for
+      RESULT=$?
+      exit $RESULT
+  else
+      if [[ $TIMEOUT -gt 0 ]]; then
+          wait_for_wrapper
+          RESULT=$?
+      else
+          wait_for
+          RESULT=$?
+      fi
+  fi
+
+  if [[ $CLI != "" ]]; then
+      if [[ $RESULT -ne 0 && $STRICT -eq 1 ]]; then
+          echoerr "$cmdname: strict mode, refusing to execute subprocess"
+          exit $RESULT
+      fi
+      exec $CLI
+  else
+      exit $RESULT
+  fi
+}
+
+main $@

--- a/wait-for-it.sh
+++ b/wait-for-it.sh
@@ -1,0 +1,152 @@
+#!/bin/bash
+cmdname=$(basename $0)
+
+echoerr() { if [[ $QUIET -ne 1 ]]; then echo "$@" 1>&2; fi }
+
+usage()
+{
+    cat << USAGE >&2
+Usage:
+    $cmdname host:port [-s] [-t timeout] [-- command args]
+    -h HOST | --host=HOST       Host or IP under test
+    -p PORT | --port=PORT       TCP port under test
+                                Alternatively, you specify the host and port as host:port
+    -s | --strict               Only execute subcommand if the test succeeds
+    -q | --quiet                Don't output any status messages
+    -t TIMEOUT | --timeout=TIMEOUT
+                                Timeout in seconds, zero for no timeout
+    -- COMMAND ARGS             Execute command with args after the test finishes
+USAGE
+    exit 1
+}
+wait_for()
+{
+    if [[ $TIMEOUT -gt 0 ]]; then
+        echoerr "$cmdname: waiting $TIMEOUT seconds for $HOST:$PORT"
+    else
+        echoerr "$cmdname: waiting for $HOST:$PORT without a timeout"
+    fi
+    start_ts=$(date +%s)
+    while :
+    do
+        (echo > /dev/tcp/$HOST/$PORT) >/dev/null 2>&1
+        result=$?
+        if [[ $result -eq 0 ]]; then
+            end_ts=$(date +%s)
+            echoerr "$cmdname: $HOST:$PORT is available after $((end_ts - start_ts)) seconds"
+            break
+        fi
+        sleep 1
+    done
+    return $result
+}
+wait_for_wrapper()
+{
+    # In order to support SIGINT during timeout: http://unix.stackexchange.com/a/57692
+    if [[ $QUIET -eq 1 ]]; then
+        timeout $TIMEOUT $0 --quiet --child --host=$HOST --port=$PORT --timeout=$TIMEOUT &
+    else
+        timeout $TIMEOUT $0 --child --host=$HOST --port=$PORT --timeout=$TIMEOUT &
+    fi
+    PID=$!
+    trap "kill -INT -$PID" INT
+    wait $PID
+    RESULT=$?
+    if [[ $RESULT -ne 0 ]]; then
+        echoerr "$cmdname: timeout occurred after waiting $TIMEOUT seconds for $HOST:$PORT"
+    fi
+    return $RESULT
+}
+# process arguments
+while [[ $# -gt 0 ]]
+do
+    case "$1" in
+        *:* )
+        hostport=(${1//:/ })
+        HOST=${hostport[0]}
+        PORT=${hostport[1]}
+        shift 1
+        ;;
+        --child)
+        CHILD=1
+        shift 1
+        ;;
+        -q | --quiet)
+        QUIET=1
+        shift 1
+        ;;
+        -s | --strict)
+        STRICT=1
+        shift 1
+        ;;
+        -h)
+        HOST="$2"
+        if [[ $HOST == "" ]]; then break; fi
+        shift 2
+        ;;
+        --host=*)
+        HOST="${1#*=}"
+        shift 1
+        ;;
+        -p)
+        PORT="$2"
+        if [[ $PORT == "" ]]; then break; fi
+        shift 2
+        ;;
+        --port=*)
+        PORT="${1#*=}"
+        shift 1
+        ;;
+        -t)
+        TIMEOUT="$2"
+        if [[ $TIMEOUT == "" ]]; then break; fi
+        shift 2
+        ;;
+        --timeout=*)
+        TIMEOUT="${1#*=}"
+        shift 1
+        ;;
+        --)
+        shift
+        CLI="$@"
+        break
+        ;;
+        --help)
+        usage
+        ;;
+        *)
+        echoerr "Unknown argument: $1"
+        usage
+        ;;
+    esac
+done
+if [[ "$HOST" == "" || "$PORT" == "" ]]; then
+    echoerr "Error: you need to provide a host and port to test."
+    usage
+fi
+TIMEOUT=${TIMEOUT:-15}
+STRICT=${STRICT:-0}
+CHILD=${CHILD:-0}
+QUIET=${QUIET:-0}
+if [[ $CHILD -gt 0 ]]; then
+    wait_for
+    RESULT=$?
+    exit $RESULT
+else
+    if [[ $TIMEOUT -gt 0 ]]; then
+        wait_for_wrapper
+        RESULT=$?
+    else
+        wait_for
+        RESULT=$?
+    fi
+fi
+if [[ $CLI != "" ]]; then
+    if [[ $RESULT -ne 0 && $STRICT -eq 1 ]]; then
+        echoerr "$cmdname: strict mode, refusing to execute subprocess"
+        exit $RESULT
+    fi
+    exec $CLI
+else
+    exit $RESULT
+fi


### PR DESCRIPTION
Added `docker` and `docker-compose` support. Details are in `documentation/installation.md`

If you have docker and docker-compose, you can now simply use `docker-compose up -d` to start everything.