### PR TITLE
Real name fallback

### DIFF
--- a/lib/helpers/doBlock.js
+++ b/lib/helpers/doBlock.js
@@ -62,7 +62,7 @@ module.exports = function doBlock(bot, message, blockChannel, blockUser) {
         }
 
         bot.api.users.info({'user':message.user}, function(err, response) {
-          userRealName = response.user.real_name;
+          userRealName = response.user.real_name || response.user.name;
           thumbUrl = response.user.profile.image_72;
           models.Standup.update(
             {

--- a/lib/helpers/doInterview.js
+++ b/lib/helpers/doInterview.js
@@ -25,7 +25,7 @@ module.exports = function doInterview(bot, interviewChannel, interviewUser, sing
       var pastBlockers = '';
 
       bot.api.users.info({'user':interviewUser}, function(err, response) {
-        userRealName = response.user.real_name;
+        userRealName = response.user.real_name || response.user.name;
         thumbUrl = response.user.profile.image_72;
       });
 


### PR DESCRIPTION
If the user hasn't entered their first or las name in their Slack profile, the `real_name` property will be empty.  In that case, fallback to their Slack handle.