### PR TITLE
Environment and deploy things

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,6 +1,6 @@
 'use strict';
 
-require('dotenv').config();
+require('./env');
 var log = require('./getLogger')('app');
 var Botkit = require('botkit');
 var schedule = require('node-schedule');
@@ -17,20 +17,9 @@ models.sequelize.sync(
   {force: false}
 );
 
-var SLACK_TOKEN = '';
-
-// Check for a Slack token
-if (process.env.SLACK_TOKEN) {
-  SLACK_TOKEN = process.env.SLACK_TOKEN;
-} else {
-  if (appEnv.getServices()) {
-    // If running on Cloud Foundry
-    SLACK_TOKEN = appEnv.getServiceCreds('standup-bot-cups').SLACK_TOKEN;
-    process.env.TIMEZONE = appEnv.getServiceCreds('standup-bot-cups').TIMEZONE;
-  } else {
-    log.error('SLACK_TOKEN not set in environment.');
-    process.exit(1);
-  }
+if (!process.env.SLACK_TOKEN) {
+  log.error('SLACK_TOKEN not set in environment.');
+  process.exit(1);
 }
 
 var bkLogger = require('./getLogger')('botkit');
@@ -73,7 +62,7 @@ var controller = Botkit.slackbot({
 
 // Initialize the bot
 controller.spawn({
-  token: SLACK_TOKEN,
+  token: process.env.SLACK_TOKEN,
   retry: 5
 }).startRTM(function(err, bot) {
   if (err) {

--- a/env.js
+++ b/env.js
@@ -1,0 +1,17 @@
+'use strict';
+
+require('dotenv').config();
+const cfenv = require('cfenv');
+const appEnv = cfenv.getAppEnv();
+
+const knownEnvs = [
+  'SLACK_TOKEN',
+  'URL'
+];
+
+if (appEnv.getServices() && Object.keys(appEnv.getServices()).length) {
+  // If running on Cloud Foundry
+  for (const env of knownEnvs) {
+    process.env[env] = appEnv.getServiceCreds('standup-bot-cups')[env];
+  }
+}

--- a/env.js
+++ b/env.js
@@ -6,6 +6,7 @@ const appEnv = cfenv.getAppEnv();
 
 const knownEnvs = [
   'SLACK_TOKEN',
+  'TIMEZONE',
   'URL'
 ];
 

--- a/migrations/20160315145654-create-model.js
+++ b/migrations/20160315145654-create-model.js
@@ -1,0 +1,102 @@
+'use strict';
+
+module.exports = {
+  up: function (queryInterface, Sequelize) {
+    /*
+      Add altering commands here.
+      Return a promise to correctly handle asynchronicity.
+
+      Example:
+      return queryInterface.createTable('users', { id: Sequelize.INTEGER });
+    */
+    return queryInterface.createTable(
+      'Channels',
+      {
+        id: {
+          type: Sequelize.INTEGER,
+          primaryKey: true,
+          autoIncrement: true
+        },
+        createdAt: {
+          type: Sequelize.DATE
+        },
+        updatedAt: {
+          type: Sequelize.DATE
+        },
+        name: {
+          type: Sequelize.STRING
+        },
+        time: {
+          type: Sequelize.INTEGER,
+          defaultValue: null
+        },
+        reminderMinutes: {
+          type: Sequelize.INTEGER,
+          defaultValue: null
+        },
+        reminderTime: {
+          type: Sequelize.INTEGER,
+          defaultValue: null
+        },
+        latestReport: {
+          type: Sequelize.STRING,
+          defaultValue: null
+        }
+      }
+    ).then(function() {
+      return queryInterface.createTable(
+        'Standups',
+        {
+          id: {
+            type: Sequelize.INTEGER,
+            primaryKey: true,
+            autoIncrement: true
+          },
+          createdAt: {
+            type: Sequelize.DATE
+          },
+          updatedAt: {
+            type: Sequelize.DATE
+          },
+          channel: {
+            type: Sequelize.STRING
+          },
+          date: {
+              type: Sequelize.DATEONLY
+          },
+          user: {
+              type: Sequelize.STRING
+          },
+          userRealName: {
+              type: Sequelize.STRING
+          },
+          thumbUrl: {
+              type: Sequelize.STRING
+          },
+          yesterday: {
+              type: Sequelize.STRING(1000)
+          },
+          today: {
+              type: Sequelize.STRING(1000)
+          },
+          blockers: {
+              type: Sequelize.STRING(1000)
+          },
+          goal: {
+              type: Sequelize.STRING(1000)
+          }
+        }
+      );
+    });
+  },
+
+  down: function (queryInterface, Sequelize) {
+    /*
+      Add reverting commands here.
+      Return a promise to correctly handle asynchronicity.
+
+      Example:
+      return queryInterface.dropTable('users');
+    */
+  }
+};


### PR DESCRIPTION
Moved cf environment handling into a separate module and added a list of expected environment variable names that will get moved over to `process.env`.  Outside of the `env.js` module, all expected variables should be accessible via `process.env[var_name]`.

Also added a "migration" create the initial database structure.  This is only useful when standing the bot up for the first time, but that's a handy time not to blow up.