### PR TITLE
Queue up conversations

### DIFF
--- a/features/start-interview.feature
+++ b/features/start-interview.feature
@@ -23,6 +23,6 @@ Feature: Start a DM convo when user emoji-reacts to reminder message
     Then the bot should start a private message with "<response>"
 
     Examples:
-      | on-time | response |
-      | is      | > I see  |
-      | is not  | > I see  |
+      | on-time | response           |
+      | is      | > :thumbsup: I see |
+      | is not  | > :thumbsup: I see |

--- a/features/start-interview.feature
+++ b/features/start-interview.feature
@@ -1,14 +1,28 @@
 Feature: Start a DM convo when user emoji-reacts to reminder message
 
+ Scenario Outline:
+   Given the bot is running
+   And I am in a room with the bot
+   And the bot ID is 'U1234567'
+   And it <on-time> before the standup report has run for the day
+   When I say "@bot interview me"
+   Then the bot should start a private message with "<response>"
+
+   Examples:
+     | on-time | response     |
+     | is      | Hey there!   |
+     | is not  | Hey there!   |
+
   Scenario Outline:
     Given the bot is running
     And I am in a room with the bot
     And the bot ID is 'U1234567'
     And it <on-time> before the standup report has run for the day
+    And I am already being interviewed for another channel
     When I say "@bot interview me"
     Then the bot should start a private message with "<response>"
 
     Examples:
-      | on-time | response     |
-      | is      | Hey there!   |
-      | is not  | Hey there!   |
+      | on-time | response |
+      | is      | > I see  |
+      | is not  | > I see  |

--- a/features/steps/common.js
+++ b/features/steps/common.js
@@ -8,6 +8,8 @@ module.exports = function() {
     module.exports.botController.hears = sinon.spy();
     module.exports.botController.on = sinon.spy();
 
+    require('../../lib/helpers/doInterview').flush();
+
     var bot = {
       reply: sinon.spy(),
       startPrivateConversation: sinon.spy(),

--- a/features/steps/common.js
+++ b/features/steps/common.js
@@ -60,8 +60,11 @@ module.exports = function() {
   this.Then(/the bot should start a private message with "([^"]+)"/, function(responseContains) {
     const bot = module.exports.botController.on.__bot;
 
+    // First check if bot.say was called.  If it was, then the bot may have
+    // sent a DM.  Check for that.
     if(bot.say.called) {
       const msg = bot.say.args[bot.say.args.length - 1][0];
+      // If the target channel is a user, then it's a DM
       if(msg.channel[0] == 'U') {
         if(msg.text.indexOf(responseContains) >= 0) {
           return true;
@@ -71,6 +74,9 @@ module.exports = function() {
         }
       }
     }
+
+    // If the bot didn't send a DM, then we should check if it started a
+    // private conversation and sent a message that way.
 
     var convo = {
       say: sinon.spy(),

--- a/features/steps/common.js
+++ b/features/steps/common.js
@@ -58,17 +58,32 @@ module.exports = function() {
   });
 
   this.Then(/the bot should start a private message with "([^"]+)"/, function(responseContains) {
+    const bot = module.exports.botController.on.__bot;
+
+    if(bot.say.called) {
+      const msg = bot.say.args[bot.say.args.length - 1][0];
+      if(msg.channel[0] == 'U') {
+        if(msg.text.indexOf(responseContains) >= 0) {
+          return true;
+        } else {
+          console.log(msg.text);
+          throw new Error('Bot reply did not contain "' + responseContains + '"');
+        }
+      }
+    }
+
     var convo = {
       say: sinon.spy(),
       ask: sinon.spy(),
       on: sinon.spy()
     };
 
-    var DmReply = module.exports.botController.on.__bot.startPrivateConversation.args[0][1];
+    var DmReply = bot.startPrivateConversation.args[0][1];
     DmReply('nothing', convo);
 
     var botResponse = convo.say.called ? convo.say : convo.ask;
     DmReply = botResponse.args[0][0];
+
     if(DmReply.indexOf(responseContains) >= 0) {
       return true;
     } else {

--- a/features/steps/start-interview.js
+++ b/features/steps/start-interview.js
@@ -9,6 +9,37 @@ module.exports = function() {
 
   var _findAllStandupsStub;
   var _findOneChannelStub;
+  var _expectConvo = true;
+
+  var clearStubs = function() {
+    if(_findOneChannelStub) {
+      _findOneChannelStub.restore();
+      _findOneChannelStub = null;
+    }
+    if(_findAllStandupsStub) {
+      _findAllStandupsStub.restore();
+      _findAllStandupsStub = null;
+    }
+  }
+
+  this.When('I am already being interviewed for another channel', function(done) {
+    botLib.startInterview(common.botController);
+
+    const message = {
+      user: 'U7654321',
+      type: 'message',
+      text: '@bot interview me',
+      channel: 'COtherChannel'
+    };
+
+    _findAllStandupsStub = sinon.stub(models.Standup, 'findAll').resolves([ ]);
+    _findOneChannelStub = sinon.stub(models.Channel, 'findOne').resolves({ time: '1230', name: message.channel, audience: null });
+
+    common.botStartsConvoWith(message, common.botController.hears, function() {
+      clearStubs();
+      done();
+    });
+  });
 
   this.When(/I say "(@bot\b.*\binterview\b.*)"/,
     function(message, done) {
@@ -24,14 +55,5 @@ module.exports = function() {
       common.botStartsConvoWith(_message, common.botController.hears, done);
   });
 
-  this.After(function() {
-    if(_findOneChannelStub) {
-      _findOneChannelStub.restore();
-      _findOneChannelStub = null;
-    }
-    if(_findAllStandupsStub) {
-      _findAllStandupsStub.restore();
-      _findAllStandupsStub = null;
-    }
-  });
+  this.After(clearStubs);
 };

--- a/lib/helpers/doInterview.js
+++ b/lib/helpers/doInterview.js
@@ -17,6 +17,11 @@ module.exports = function doInterview(bot, interviewChannel, interviewUser, sing
   userInterviewQueue[interviewUser].push({
     bot, interviewChannel, interviewUser, singleSection
   });
+module.exports.flush = function() {
+  for(let user of Object.keys(userInterviewQueue)) {
+    userInterviewQueue[user].destroy();
+    delete userInterviewQueue[user];
+  }
 };
 
 function handleQueuedItem(obj, taskFinished) {

--- a/lib/helpers/doInterview.js
+++ b/lib/helpers/doInterview.js
@@ -12,10 +12,13 @@ const userInterviewQueue = { };
 
 module.exports = function doInterview(bot, interviewChannel, interviewUser, singleSection) {
   if(!userInterviewQueue[interviewUser]) {
-    userInterviewQueue[interviewUser] = new Queue(handleQueuedItem);
+    userInterviewQueue[interviewUser] = {
+     queue: new Queue(handleQueuedItem),
+     current: ''
+   };
   }
-  userInterviewQueue[interviewUser].push({
-    bot, interviewChannel, interviewUser, singleSection
+  userInterviewQueue[interviewUser].queue.push({
+    bot, interviewChannel, interviewUser, singleSection, position: userInterviewQueue[interviewUser].queue.length
   });
 
   if(userInterviewQueue[interviewUser].queue.length > 0) {
@@ -28,16 +31,17 @@ module.exports = function doInterview(bot, interviewChannel, interviewUser, sing
 
 module.exports.flush = function() {
   for(let user of Object.keys(userInterviewQueue)) {
-    userInterviewQueue[user].destroy();
+    userInterviewQueue[user].queue.destroy();
     delete userInterviewQueue[user];
   }
 };
 
-function handleQueuedItem(obj, taskFinished) {
-  const bot = obj.bot;
-  const interviewUser = obj.interviewUser;
-  const interviewChannel = obj.interviewChannel;
-  const singleSection = obj.singleSection;
+function handleQueuedItem(dequeuedObject, taskFinished) {
+  const bot = dequeuedObject.bot;
+  const interviewUser = dequeuedObject.interviewUser;
+  const interviewChannel = dequeuedObject.interviewChannel;
+  const singleSection = dequeuedObject.singleSection;
+  userInterviewQueue[interviewUser].current = interviewChannel;
 
   log.verbose('Starting an interview with '+interviewUser+' for channel ' + interviewChannel);
 
@@ -109,7 +113,13 @@ function handleQueuedItem(obj, taskFinished) {
                   ]);
               }
             } else {
-              convo.say('Hey there! Let\'s record your standup for <#'+interviewChannel+'>'+
+              let intro = `Hey there! Let's`;
+              if(dequeuedObject.position > 0) {
+                // The position is only zero if the queue was empty
+                // when this standup was added.
+                intro = `Alright, now let's`;
+              }
+              convo.say(`${intro} record your standup for <#${interviewChannel}>`+
                 ' (Say "skip" to skip any of the questions or "exit" to stop):');
               resolve();
             }

--- a/lib/helpers/doInterview.js
+++ b/lib/helpers/doInterview.js
@@ -3,11 +3,28 @@
 var log = require('../../getLogger')('interview recorder');
 var models = require('../../models');
 var moment = require('moment');
+var Queue = require('better-queue');
 var timeHelper = require('./time');
 var standupHelper = require('./getStandupReport');
 var reportHelper = require('./doChannelReport');
 
+const userInterviewQueue = { };
+
 module.exports = function doInterview(bot, interviewChannel, interviewUser, singleSection) {
+  if(!userInterviewQueue[interviewUser]) {
+    userInterviewQueue[interviewUser] = new Queue(handleQueuedItem);
+  }
+  userInterviewQueue[interviewUser].push({
+    bot, interviewChannel, interviewUser, singleSection
+  });
+};
+
+function handleQueuedItem(obj, taskFinished) {
+  const bot = obj.bot;
+  const interviewUser = obj.interviewUser;
+  const interviewChannel = obj.interviewChannel;
+  const singleSection = obj.singleSection;
+
   log.verbose('Starting an interview with '+interviewUser+' for channel ' + interviewChannel);
 
   models.Channel.findOne({
@@ -248,6 +265,10 @@ module.exports = function doInterview(bot, interviewChannel, interviewUser, sing
               } else {
                 // something happened that caused the conversation to stop prematurely
               }
+
+              // In any case, now that the convo is done, signal that the queued
+              // task is finished so we can move on.
+              taskFinished();
             });
           });
         });

--- a/lib/helpers/doInterview.js
+++ b/lib/helpers/doInterview.js
@@ -20,7 +20,7 @@ module.exports = function doInterview(bot, interviewChannel, interviewUser, sing
 
   if(userInterviewQueue[interviewUser].queue.length > 0) {
     bot.say({
-      text: `> I see you also want to do a standup for <#${interviewChannel}>, but you're already doing one.  Once you finish this one up, I'll ask you for your info for <#${interviewChannel}>!`,
+      text: `> :thumbsup: I see you also want to do a standup for <#${interviewChannel}>, but you're already doing one for <#${userInterviewQueue[interviewUser].current}>.  Once you finish this one up, I'll ask you for your info for <#${interviewChannel}>!`,
       channel: interviewUser
     });
   }

--- a/lib/helpers/doInterview.js
+++ b/lib/helpers/doInterview.js
@@ -17,6 +17,13 @@ module.exports = function doInterview(bot, interviewChannel, interviewUser, sing
   userInterviewQueue[interviewUser].push({
     bot, interviewChannel, interviewUser, singleSection
   });
+
+  if(userInterviewQueue[interviewUser].queue.length > 0) {
+    bot.say({
+      text: `> I see you also want to do a standup for <#${interviewChannel}>, but you're already doing one.  Once you finish this one up, I'll ask you for your info for <#${interviewChannel}>!`,
+      channel: interviewUser
+    });
+  }
 };
 
 module.exports.flush = function() {

--- a/lib/helpers/doInterview.js
+++ b/lib/helpers/doInterview.js
@@ -254,35 +254,31 @@ function handleQueuedItem(obj, taskFinished) {
                       var channelTime = timeHelper.getDisplayFormat(channel.time);
                       if (moment(now, 'hh:mm a Z').isBefore(moment(channelTime, 'hh:mm a Z'))) {
                         log.verbose('Standup info recorded for ' + userRealName);
-                        bot.startPrivateConversation({user: interviewUser}, function(response, convo){
-                          convo.say({
-                            text: 'Thanks! Your standup for <#'+interviewChannel+
-                            '> is recorded and will be reported at ' +
-                            timeHelper.getDisplayFormat(channel.time) +
-                            '.  It will look like:',
-                            attachments: [ standupHelper(standup) ]
-                          });
+                        bot.say({
+                          text: 'Thanks! Your standup for <#'+interviewChannel+
+                          '> is recorded and will be reported at ' +
+                          timeHelper.getDisplayFormat(channel.time) +
+                          '.  It will look like:',
+                          attachments: [ standupHelper(standup) ],
+                          channel: interviewUser
                         });
                       } else {
                         log.verbose('Late report from '+userRealName+'; updating previous report');
-                        bot.startPrivateConversation({user: interviewUser}, function(response, convo){
-                          convo.say({
-                            text: 'Thanks! Your standup for <#'+interviewChannel+
-                            '> is recorded and and the existing report will be updated!'
-                          });
+                        bot.say({
+                          text: 'Thanks! Your standup for <#'+interviewChannel+
+                          '> is recorded and and the existing report will be updated!',
+                          channel: interviewUser
                         });
                         reportHelper(bot, interviewChannel, true, userRealName);
                       }
+                      taskFinished();
                     });
                   });
                 });
               } else {
                 // something happened that caused the conversation to stop prematurely
+                taskFinished();
               }
-
-              // In any case, now that the convo is done, signal that the queued
-              // task is finished so we can move on.
-              taskFinished();
             });
           });
         });

--- a/lib/helpers/doInterview.js
+++ b/lib/helpers/doInterview.js
@@ -17,6 +17,8 @@ module.exports = function doInterview(bot, interviewChannel, interviewUser, sing
   userInterviewQueue[interviewUser].push({
     bot, interviewChannel, interviewUser, singleSection
   });
+};
+
 module.exports.flush = function() {
   for(let user of Object.keys(userInterviewQueue)) {
     userInterviewQueue[user].destroy();

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@18f/us-federal-holidays": "^1.1.0",
     "@erdc-itl/simple-logger": "^1.1.0",
     "async": "^1.5.2",
+    "better-queue": "^3.8.4",
     "botkit": "^0.4.0",
     "cfenv": "^1.0.3",
     "dotenv": "^2.0.0",


### PR DESCRIPTION
When a user indicates that they want to start a standup conversation, that gets added to the queue.  Interviews are handled in a FIFO manner from the queue.  If the queue was empty when the standup arrived, the interview will begin pretty much immediately.  Otherwise, the user is notified by DM that the bot got their request and will start the new interview when they're done with the current one.

Closes #99.