### PR TITLE
Automatic out-of-office reports

### DIFF
--- a/app.js
+++ b/app.js
@@ -119,6 +119,9 @@ controller.spawn({
       // Set a standup audience to a user group
       botLib.setAudience(controller);
 
+      // Set yourself OOO for some time
+      botLib.setOutOfOffice(controller);
+
       // Get a weekly user report
       botLib.userReport(controller);
 

--- a/app.js
+++ b/app.js
@@ -94,6 +94,11 @@ controller.spawn({
       // TODO: add usage messages
       botLib.giveHelp(controller, identity.name);
 
+      // Set yourself OOO for some time.  Put this above getStandupInfo
+      // because getStandupInfo catches anything that starts with "#channel",
+      // so catch the more precise 
+      botLib.setOutOfOffice(controller);
+
       botLib.getStandupInfo(controller);
 
       // TODO: remind people to do standup?
@@ -118,9 +123,6 @@ controller.spawn({
 
       // Set a standup audience to a user group
       botLib.setAudience(controller);
-
-      // Set yourself OOO for some time
-      botLib.setOutOfOffice(controller);
 
       // Get a weekly user report
       botLib.userReport(controller);

--- a/documentation/interaction.md
+++ b/documentation/interaction.md
@@ -40,6 +40,28 @@ If you sent your standup as block text, you can edit that message to edit your s
 
 Finally, you can send the bot another block text DM.  Any sections you supply in the new standup block text will overwrite the previous standup.
 
+## Setting yourself out-of-office
+
+If you know you'll be out of the office for a few days and would like the bot to automatically post standups on your behalf while you're away, you can tell it you'll be gone.  To do that, you can either tell the bot in the channel that you want to automatically report in:
+
+```
+@standup-bot I'll be out of the office for 3 days
+```
+
+Or you can send the bot a DM and tell it which channel to automatically report in:
+
+```
+#channel out of the office for 3 days
+```
+
+The bot understands over variations of these messages.  Here are some examples:
+
+```
+@standup-bot out of office 3 days
+@standup-bot out of office 3
+@standup-bot ooo 3
+```
+
 ## Get help
 
 The bot can provide a quick reference to using it.  To trigger the bot's in-Slack help, just say `help` in a DM or `@standup-bot help` in any channel the bot is in.

--- a/lib/bot/index.js
+++ b/lib/bot/index.js
@@ -14,5 +14,6 @@ module.exports = {
   startInterview: require('./startInterview'),
   removeStandup: require('./removeStandup'),
   setAudience: require('./setAudience'),
+  setOutOfOffice: require('./setOutOfOffice'),
   userReport: require('./userReport')
 };

--- a/lib/bot/setOutOfOffice.js
+++ b/lib/bot/setOutOfOffice.js
@@ -22,9 +22,11 @@ function setUserOOOForDate(user, username, thumb, channel, date) {
 }
 
 function setOOO(bot, message) {
+  const oooChannel = message.match[1];
+
   models.Channel.findOne({
     where: {
-      name: message.channel
+      name: oooChannel
     }
   }).then(channel => {
     if (channel) {
@@ -45,24 +47,37 @@ function setOOO(bot, message) {
               message.user,
               userRealName,
               thumbUrl,
-              message.channel,
+              oooChannel,
               helpers.time.getReportFormat(target)
             )
           );
         }
 
         Promise.all(awaiting).then(() => {
-          bot.reply(message, `Okay, <@${message.user}>, I've marked you out-of-office for the next ${days} days!`);
+          if(message.channel !== oooChannel) {
+            bot.reply(message, `Okay, <@${message.user}>, I've marked you out-of-office for <#${oooChannel}> for the next ${days} days!`);
+          } else {
+            bot.reply(message, `Okay, <@${message.user}>, I've marked you out-of-office for the next ${days} days!`);
+          }
         });
       });
     } else {
-      bot.reply(message, `There's no standup scheduled for <#${message.channel}>`);
+      bot.reply(message, `There's no standup scheduled for <#${oooChannel}>`);
     }
   });
 }
 
 function attachListener(controller) {
-  controller.hears(['(ooo()( for)?) (\\d+)', '(out of (the )?office( for)?) (\\d+)'],['direct_mention'], setOOO);
+  controller.hears(['<#(\\S*?)(\\|\\S*)?> (ooo|out of (the )?office( for)?) (\\d+)'],['direct_message'], (bot, message) => {
+    // Normalize the message so that the index-4 element is the OOO duration
+    message.match[4] = message.match[6]
+    setOOO(bot, message);
+  });
+  controller.hears(['(ooo()( for)?) (\\d+)', '(out of (the )?office( for)?) (\\d+)'],['direct_mention'], (bot, message) => {
+    // Normalize the message so that the index-1 element is the OOO channel
+    message.match[1] = message.channel;
+    setOOO(bot, message);
+  });
   log.verbose('Attached');
 }
 

--- a/lib/bot/setOutOfOffice.js
+++ b/lib/bot/setOutOfOffice.js
@@ -1,0 +1,69 @@
+'use strict';
+
+const moment = require('moment');
+const models = require('../../models');
+const helpers = require('../helpers');
+const log = require('../../getLogger')('set ooo');
+
+function setUserOOOForDate(user, username, thumb, channel, date) {
+  return models.Standup.findOrCreate({
+    where: {
+      channel,
+      date,
+      user
+    }
+  }).then(standupArr => {
+    const standup = standupArr[0];
+    standup.userRealName = username;
+    standup.thumbUrl = thumb;
+    standup.today = 'Out of Office';
+    return standup.save();
+  })
+}
+
+function setOOO(bot, message) {
+  models.Channel.findOne({
+    where: {
+      name: message.channel
+    }
+  }).then(channel => {
+    if (channel) {
+      const days = Number(message.match[4]);
+      const today = helpers.time.getReportFormat();
+      const target = moment(today, 'YYYY-MM-DD');
+
+      bot.api.users.info({'user':message.user}, function(err, response) {
+        const userRealName = response.user.real_name || response.user.name;
+        const thumbUrl = response.user.profile.image_72;
+
+        const awaiting = [];
+
+        for(let i = 0; i < days; i++) {
+          target.add(1, 'd');
+          awaiting.push(
+            setUserOOOForDate(
+              message.user,
+              userRealName,
+              thumbUrl,
+              message.channel,
+              helpers.time.getReportFormat(target)
+            )
+          );
+        }
+
+        Promise.all(awaiting).then(() => {
+          bot.reply(message, `Okay, <@${message.user}>, I've marked you out-of-office for the next ${days} days!`);
+        });
+      });
+    } else {
+      bot.reply(message, `There's no standup scheduled for <#${message.channel}>`);
+    }
+  });
+}
+
+function attachListener(controller) {
+  controller.hears(['(ooo()( for)?) (\\d+)', '(out of (the )?office( for)?) (\\d+)'],['direct_mention'], setOOO);
+  log.verbose('Attached');
+}
+
+module.exports = attachListener;

--- a/lib/helpers/doChannelReport.js
+++ b/lib/helpers/doChannelReport.js
@@ -83,14 +83,15 @@ module.exports = function doChannelReport(bot, reportChannel, update, userRealNa
           // Find people who are out of office (OOO) today
           var pager = '';
           var ooo = '';
-          for (var a in attachments) {
-            if (attachments[a].fields[1]) {
-              const today = attachments[a].fields[1].value;
-              if (today.search(/:pager:/) >= 0) {
-                pager += '- '+attachments[a].title + '\n';
-              }
-              if (today.toLowerCase() === 'ooo' || today.toLowerCase() === 'out of office') {
-                ooo += '- '+attachments[a].title + '\n';
+          for (let attachment of attachments) {
+            for (let field of attachment.fields) {
+              if (field.title === 'Today') {
+                if (field.value.search(/:pager:/) >= 0) {
+                  pager += '- '+attachment.title + '\n';
+                }
+                if (field.value.toLowerCase() === 'ooo' || field.value.toLowerCase() === 'out of office') {
+                  ooo += '- '+attachment.title + '\n';
+                }
               }
             }
           }

--- a/lib/helpers/doChannelReport.js
+++ b/lib/helpers/doChannelReport.js
@@ -85,10 +85,11 @@ module.exports = function doChannelReport(bot, reportChannel, update, userRealNa
           var ooo = '';
           for (var a in attachments) {
             if (attachments[a].fields[1]) {
-              if (attachments[a].fields[1].value.search(/:pager:/) >= 0) {
+              const today = attachments[a].fields[1].value;
+              if (today.search(/:pager:/) >= 0) {
                 pager += '- '+attachments[a].title + '\n';
               }
-              if (attachments[a].fields[1].value.search(/\bOOO\b/i) >= 0) {
+              if (today.toLowerCase() === 'ooo' || today.toLowerCase() === 'out of office') {
                 ooo += '- '+attachments[a].title + '\n';
               }
             }


### PR DESCRIPTION
Users can set themselves out-of-office to have the bot automatically report on their behalf.  The following is from the new documentation:

---

If you know you'll be out of the office for a few days and would like the bot to automatically post standups on your behalf while you're away, you can tell it you'll be gone.  To do that, you can either tell the bot in the channel that you want to automatically report in:

```
@standup-bot I'll be out of the office for 3 days
```

Or you can send the bot a DM and tell it which channel to automatically report in:

```
#channel out of the office for 3 days
```

The bot understands over variations of these messages.  Here are some examples:

```
@standup-bot out of office 3 days
@standup-bot out of office 3
@standup-bot ooo 3
```

---

Will close #70