### PR TITLE
Make help text friendlier

### DIFF
--- a/documentation/overview.md
+++ b/documentation/overview.md
@@ -1,13 +1,14 @@
 {{full_help}}
 ## Creating a standup
 
-To create a standup, I must be in a channel.  Then, say:
+To create a standup, I must be in a channel - you can invite me with
+`/invite @{{bot_name}}`.  Then, in that channel, say:
 
 ```
 @{{bot_name}} create standup <time> [days]
 ```
 
-in that channel.  The time is required and will be assumed to be in the
+The time is required and will be assumed to be in the
 {{timezone}} timezone.  Days are optional - if omitted, the standup will
 run every weekday.  If provided, days should be separated by spaces.  For
 example:

--- a/documentation/overview.md
+++ b/documentation/overview.md
@@ -1,0 +1,41 @@
+{{full_help}}
+## Creating a standup
+
+To create a standup, I must be in a channel.  Then, say:
+
+```
+@{{bot_name}} create standup <time> [days]
+```
+
+in that channel.  The time is required and will be assumed to be in the
+{{timezone}} timezone.  Days are optional - if omitted, the standup will
+run every weekday.  If provided, days should be separated by spaces.  For
+example:
+
+```
+@{{bot_name}} create standup 10:30am Monday Wednesday Friday
+```
+
+* To create a reminder for a standup, you can just tell me `@{{bot_name}} reminder <minutes before standup>`
+* By default, I don't use any @-notices when posting the standup reminder, but you can set an audience that should be notified by saying `@{{bot_name}} audience <target>`. The target can be `@here`, `@channel`, `@<user-group>`, etc.
+* To remove an existing standup, message me from the channel where the standup is currently scheduled with `@{{bot_name}} remove standup`
+
+---
+
+## Submitting your standup
+
+If I'm configured to send a reminder, you can just add an emoji
+response to my reminder message (or any of my other messages) and I
+will start an interview with you via DM.  You can also DM me just
+the channel name to start the interview.
+
+You can also send me your standup in a single message by sending me
+a DM like this:
+
+```
+#channel-name
+y: what you did yesterday
+t: what you did today
+b: what's in your way (blockers)
+g: what main thing you hope to accomplish (goal)
+```

--- a/features/give-help.feature
+++ b/features/give-help.feature
@@ -4,10 +4,10 @@ Feature: Get usage help
     Given the bot is running
     And I am in a room with the bot
     When I say "@bot help"
-    Then the bot should respond "To log your standup"
+    Then the bot should upload a post
 
   Scenario: I ask for help in a DM
     Given the bot is running
     And I am in a room with the bot
     When I DM the bot with "help"
-    Then the bot should respond "To log your standup"
+    Then the bot should upload a post

--- a/features/steps/common.js
+++ b/features/steps/common.js
@@ -30,6 +30,9 @@ module.exports = function() {
         },
         channels: {
           info: sinon.stub().yields(null, { channel: { name: 'CSomethingSaySomething'}})
+        },
+        files: {
+          upload: sinon.stub().yields(null, {})
         }
       }
     };
@@ -113,6 +116,21 @@ module.exports = function() {
       }
     }
     throw new Error(`Bot reply did not contain an attachment saying "${responseContains}"`);
+  });
+
+  this.Then('the bot should upload a post', function() {
+    const bot = module.exports.botController.on.__bot;
+
+    if(bot.api.files.upload.called && bot.api.files.upload.args.length > 0) {
+      const file = bot.api.files.upload.args[0][0];
+      if(file && file.filetype === 'post') {
+        return true;
+      } else {
+        throw new Error('Bot did not upload a post');
+      }
+    }
+
+    throw new Error('Bot did not upload anything');
   });
 
   var _standupFindStub;

--- a/features/steps/give-help.js
+++ b/features/steps/give-help.js
@@ -2,14 +2,14 @@
 var botLib = require('../../lib/bot');
 var common = require('./common');
 
-module.exports = function() {
-  this.When('I say "@bot help"', function(done) {
-    botLib.giveHelp(common.botController);
-    common.botRepliesToHearing({ }, done);
-  });
+const doIt = () => {
+  botLib.giveHelp(common.botController);
+  const fn = common.botController.hears;
+  const handler = fn.args[0][fn.args[0].length - 1];
+  handler(fn.__bot, {});
+}
 
-  this.When('I DM the bot with "help"', function(done) {
-    botLib.giveHelp(common.botController);
-    common.botRepliesToHearing({ }, done);
-  });
+module.exports = function() {
+  this.When('I say "@bot help"', doIt);
+  this.When('I DM the bot with "help"', doIt);
 };

--- a/lib/bot/giveHelp.js
+++ b/lib/bot/giveHelp.js
@@ -2,6 +2,7 @@
 const fs = require('fs');
 const mustache = require('mustache');
 const timezone = process.env.TIMEZONE || 'America/New_York';
+const log = require('../../getLogger')('help giver');
 
 const overviewDoc = fs.readFileSync('./documentation/overview.md', { encoding: 'utf-8' });
 
@@ -19,6 +20,10 @@ function attachListener(controller, botName) {
       filetype: 'post',
       content: helpFile,
       channels: message.channel
+    }, function(err) {
+      if(err) {
+        log.error(err);
+      }
     });
   });
 }

--- a/lib/bot/giveHelp.js
+++ b/lib/bot/giveHelp.js
@@ -22,7 +22,7 @@ function attachListener(controller, botName) {
       channels: message.channel
     }, function(err) {
       if(err) {
-        log.error(err);
+        bot.reply(message, helpFile);
       }
     });
   });

--- a/lib/bot/giveHelp.js
+++ b/lib/bot/giveHelp.js
@@ -1,28 +1,25 @@
 'use strict';
+const fs = require('fs');
+const mustache = require('mustache');
+const timezone = process.env.TIMEZONE || 'America/New_York';
 
+const overviewDoc = fs.readFileSync('./documentation/overview.md', { encoding: 'utf-8' });
 
 function attachListener(controller, botName) {
   controller.hears(['^(help|usage)'],['direct_mention','direct_message'], function(bot, message) {
-    var helpMessage =
-
-      '- To create a standup, say `@'+botName+' create standup [time]` in a channel. That\'ll create a standup for every weekday. You can also specify just certain weekdays: `@'+botName+' create standup [time] [days]`, where `days` is a list of space-separate days, such as `M W F` or `T Th`\n'+
-      '- To create a reminder for that standup, say `@'+botName+' reminder [minutes before standup]`\n'+
-      '- To log your standup response, either emoji that reminder or DM me with the following format '+
-      '```#channel-name\ny: what I did yesterday\nT: what I\'m doing today\n'+
-      'b: what\'s in my way\ng: what main thing I hope to accomplish```\n'+
-      '- To remove a standup, say `@'+botName+' remove standup` in the channel where it\'s '+
-      'scheduled\nBy default, notifications are sent with @-here, but you can change that to '+
-      'something else—like a user group or @-channel—by saying `@'+botName+
-      ' audience [notification]`\n'+
-      '- To get a report of past standup responses, DM me with `report` or say `@'+botName+' report` in the '+
-      'channel you\'re curious about. To customize that report,'+
-      ' say any combination of `report [user] [channel] [days]`';
-
+    let fullHelp = '';
     if(process.env.URL) {
-      helpMessage += '\n\nFor more help, see ' + process.env.URL;
+      fullHelp = `Here's some helpful tips.  You can also check out my [full standup-bot documentation](${process.env.URL}).\n\n`;
     }
+    const helpFile = mustache.render(overviewDoc, { bot_name: botName, timezone, full_help: fullHelp });
 
-    bot.reply(message, helpMessage);
+    bot.api.files.upload({
+      title:'standup-bot help',
+      filename: 'standup-bot-help.md',
+      filetype: 'post',
+      content: helpFile,
+      channels: message.channel
+    });
   });
 }
 


### PR DESCRIPTION
This PR moves the help text into a Slack post instead of just a regular message.  This allows it to be formatted as Markdown and also lets users collapse it if they don't want to see it (e.g., if someone asked for help in a channel):

![screen shot 2017-01-03 at 12 06 34 pm](https://cloud.githubusercontent.com/assets/1775733/21617765/48df9bf2-d1ad-11e6-9862-8102e0bb2e81.png)

Closes #64