### PR TITLE
Requires fully-formed Slack names for audience

### DIFF
--- a/lib/bot/setAudience.js
+++ b/lib/bot/setAudience.js
@@ -47,7 +47,7 @@ function setUserGroup(bot, message) {
 }
 
 function attachListener(controller) {
-  controller.hears(['(usergroup|audience) (<!(subteam|here|channel).*>)'],['direct_mention'], setUserGroup);
+  controller.hears(['(usergroup|audience) (<!(subteam|here|channel).*?>)'],['direct_mention'], setUserGroup);
   log.verbose('Attached');
 }
 

--- a/lib/bot/setAudience.js
+++ b/lib/bot/setAudience.js
@@ -47,7 +47,7 @@ function setUserGroup(bot, message) {
 }
 
 function attachListener(controller) {
-  controller.hears(['(usergroup|audience) (<!subteam\\^\\S*>)'],['direct_mention'], setUserGroup);
+  controller.hears(['(usergroup|audience) (<!(subteam|here|channel).*>)'],['direct_mention'], setUserGroup);
   log.verbose('Attached');
 }
 

--- a/lib/bot/setAudience.js
+++ b/lib/bot/setAudience.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var log = require('../../getLogger')('create standup');
+var log = require('../../getLogger')('set audience');
 var models = require('../../models');
 var _ = require('underscore');
 
@@ -47,7 +47,7 @@ function setUserGroup(bot, message) {
 }
 
 function attachListener(controller) {
-  controller.hears(['(usergroup|audience) (\\S*)'],['direct_mention'], setUserGroup);
+  controller.hears(['(usergroup|audience) (<!subteam\\^\\S*>)'],['direct_mention'], setUserGroup);
   log.verbose('Attached');
 }
 


### PR DESCRIPTION
E.g., `@here`, `@channel`, `@user-group`.  That way they can be stored as proper IDs and will keep working even if the usergroup name changes.

Closes #63 