### PR TITLE
Add first emoji reaction to bot reminders

### DIFF
--- a/lib/bot/getReminderRunner.js
+++ b/lib/bot/getReminderRunner.js
@@ -37,7 +37,15 @@ function runReports(anytimeBot) {
           attachments: [],
           channel: channel.name
         };
-        anytimeBot.say(reminder);
+        anytimeBot.say(reminder, function(err, response) {
+          if(!err) {
+            anytimeBot.api.reactions.add({
+              name: 'wave',
+              channel: channel.name,
+              timestamp: response.message.ts
+            });
+          }
+        });
       });
     }
   });

--- a/lib/bot/startDmEmoji.js
+++ b/lib/bot/startDmEmoji.js
@@ -10,7 +10,7 @@ function startDmEmoji(bot, message) {
 
 function attachListener(controller, botId) {
   controller.on('reaction_added', function(bot, message) {
-    if (message.item_user === botId) {
+    if (message.item_user === botId && message.user !== botId) {
       startDmEmoji(bot, message);
     }
   });


### PR DESCRIPTION
This way, users can just click that first emoji rather than having to add one.  Super minor little thing, but hey, there it is.  Also make the bot ignore its own reactions so it doesn't try to converse with itself.

Closes #83 