### PR TITLE
Turn tests back on

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,10 @@ jobs:
     docker:
       - image: circleci/node:6
     steps:
-      - run: echo "no tests"
+      - checkout
+      - run: npm install
+      - run: npm test
+      - run: ./node_modules/.bin/codecov
   deploy:
     docker:
       - image: 18fgsa/cloud-foundry-cli


### PR DESCRIPTION
I mistakenly believed we didn't have tests, so I put in a noop `echo` instead of running the tests.  This PR adds the tests back to the CI process.