### PR TITLE
Only respond to emoji in channels with standups

### DIFF
--- a/lib/bot/startDmEmoji.js
+++ b/lib/bot/startDmEmoji.js
@@ -10,7 +10,7 @@ function startDmEmoji(bot, message) {
 
 function attachListener(controller, botId) {
   controller.on('reaction_added', function(bot, message) {
-    if (message.item_user === botId && message.user !== botId) {
+    if (message.item_user === botId && message.user !== botId && message.item.channel[0] === 'C') {
       startDmEmoji(bot, message);
     }
   });

--- a/lib/bot/startDmEmoji.js
+++ b/lib/bot/startDmEmoji.js
@@ -1,16 +1,22 @@
 'use strict';
 
 var log = require('../../getLogger')('emoji response');
+var models = require('../../models');
 var helpers = require('../helpers');
 
 function startDmEmoji(bot, message) {
-  log.verbose('Got an emoji reaction: '+message.reaction+' from '+message.user);
-  helpers.doInterview(bot, message.item.channel, message.user);
+  models.Channel.findOne({ where: { name: message.item.channel }})
+    .then((channel) => {
+      if (channel) {
+        log.verbose(`Got an emoji reaction: ${message.reaction} from ${message.user}`);
+        helpers.doInterview(bot, message.item.channel, message.user);
+      }
+    });
 }
 
 function attachListener(controller, botId) {
   controller.on('reaction_added', function(bot, message) {
-    if (message.item_user === botId && message.user !== botId && message.item.channel[0] === 'C') {
+    if (message.item_user === botId && message.user !== botId) {
       startDmEmoji(bot, message);
     }
   });


### PR DESCRIPTION
When the bot gets an emoji, first make sure that there's a standup in that channel.  If not, don't do anything.  I originally made it ignore non-public channels, but that'd be an extra wrinkle for #82 somewhere down the road, plus group DM channel IDs can start with a `C`, just like public channels, so... 🤷‍♀️

Closes #131