### PR TITLE
Orchestrate workflow so deploy comes AFTER tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,6 +22,8 @@ workflows:
     jobs:
       - test
       - deploy:
+          requires:
+            - test
           filters:
             branches:
               only:


### PR DESCRIPTION
As is, testing and deploying are independent, so a deploy can happen before tests.  That's bad.  Make deploys depend on successful tests.