### PR TITLE
Remove vulnerable dependency

### DIFF
--- a/lib/web/buildPage.js
+++ b/lib/web/buildPage.js
@@ -2,7 +2,7 @@
 
 const fs = require('fs');
 const path = require('path');
-const marked = require('marked');
+const marked = require('marky-markdown');
 const mustache = require('mustache');
 
 module.exports = function buildPage() {

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -753,6 +753,16 @@
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
     },
+    "atom-language-diff": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/atom-language-diff/-/atom-language-diff-1.0.2.tgz",
+      "integrity": "sha1-OVvEkRt+GnW90l3I1tXFHJxvnBk="
+    },
+    "atom-language-nginx": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/atom-language-nginx/-/atom-language-nginx-0.6.1.tgz",
+      "integrity": "sha1-PreIvyZMpaIhBDoLx1FlfpXe8oU="
+    },
     "aws-sign2": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
@@ -808,8 +818,7 @@
     "balanced-match": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz",
-      "integrity": "sha1-qRzdHr7xqGZZ5w/03vAWJfwtZ1Y=",
-      "dev": true
+      "integrity": "sha1-qRzdHr7xqGZZ5w/03vAWJfwtZ1Y="
     },
     "base62": {
       "version": "1.2.0",
@@ -1196,7 +1205,6 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
       "integrity": "sha1-Rr/1ARXUf8mriYVKu4fZgHihCZE=",
-      "dev": true,
       "requires": {
         "balanced-match": "0.3.0",
         "concat-map": "0.0.1"
@@ -1469,6 +1477,11 @@
         "urlgrey": "0.4.1"
       }
     },
+    "coffee-script": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.9.0.tgz",
+      "integrity": "sha1-dJLLvD8DYcxdiGWv9yN1Uv8z4fc="
+    },
     "colors": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
@@ -1637,6 +1650,14 @@
       "resolved": "https://registry.npmjs.org/crypto/-/crypto-0.0.3.tgz",
       "integrity": "sha1-RwqBuGvkxe4XrMggeh9TFa4g27A="
     },
+    "cson-parser": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/cson-parser/-/cson-parser-1.0.9.tgz",
+      "integrity": "sha1-t5/BuCp3V0NoDw7/uL+tMRNNrHQ=",
+      "requires": {
+        "coffee-script": "1.9.0"
+      }
+    },
     "cucumber": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/cucumber/-/cucumber-1.3.3.tgz",
@@ -1777,7 +1798,6 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
       "integrity": "sha1-BzxpdUbOB4DOI75KKOKT5AvDDII=",
-      "dev": true,
       "requires": {
         "domelementtype": "1.1.3",
         "entities": "1.1.1"
@@ -1786,14 +1806,12 @@
         "domelementtype": {
           "version": "1.1.3",
           "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz",
-          "integrity": "sha1-vSh3PiZCiBrsUVRJJCmcXNgiGFs=",
-          "dev": true
+          "integrity": "sha1-vSh3PiZCiBrsUVRJJCmcXNgiGFs="
         },
         "entities": {
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz",
-          "integrity": "sha1-blwtClYhtdra7O+AuQ7ftc13cvA=",
-          "dev": true
+          "integrity": "sha1-blwtClYhtdra7O+AuQ7ftc13cvA="
         }
       }
     },
@@ -1805,14 +1823,12 @@
     "domelementtype": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz",
-      "integrity": "sha1-sXrtguirWeUt2cGbF1bg/BhyBMI=",
-      "dev": true
+      "integrity": "sha1-sXrtguirWeUt2cGbF1bg/BhyBMI="
     },
     "domhandler": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.3.0.tgz",
       "integrity": "sha1-LeWaCCLVAn+r/28DLCsloqir5zg=",
-      "dev": true,
       "requires": {
         "domelementtype": "1.3.0"
       }
@@ -1821,7 +1837,6 @@
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
       "integrity": "sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=",
-      "dev": true,
       "requires": {
         "dom-serializer": "0.1.0",
         "domelementtype": "1.3.0"
@@ -1896,6 +1911,54 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
+    },
+    "emissary": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/emissary/-/emissary-1.3.3.tgz",
+      "integrity": "sha1-phjZLWgrIy0xER3DYlpd9mF5lgY=",
+      "requires": {
+        "es6-weak-map": "0.1.4",
+        "mixto": "1.0.0",
+        "property-accessors": "1.1.3",
+        "underscore-plus": "1.6.6"
+      },
+      "dependencies": {
+        "es6-iterator": {
+          "version": "0.1.3",
+          "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-0.1.3.tgz",
+          "integrity": "sha1-1vWLjE/EE8JJtLqhl2j45NfIlE4=",
+          "requires": {
+            "d": "0.1.1",
+            "es5-ext": "0.10.11",
+            "es6-symbol": "2.0.1"
+          }
+        },
+        "es6-symbol": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-2.0.1.tgz",
+          "integrity": "sha1-dhtcZ8/U8dGK+yNPaR1nhoLLO/M=",
+          "requires": {
+            "d": "0.1.1",
+            "es5-ext": "0.10.11"
+          }
+        },
+        "es6-weak-map": {
+          "version": "0.1.4",
+          "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-0.1.4.tgz",
+          "integrity": "sha1-cGzvnpmqI2undmwjnIueKG6n0ig=",
+          "requires": {
+            "d": "0.1.1",
+            "es5-ext": "0.10.11",
+            "es6-iterator": "0.1.3",
+            "es6-symbol": "2.0.1"
+          }
+        }
+      }
+    },
+    "emoji-regex": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-6.1.1.tgz",
+      "integrity": "sha1-xs0OwbBkLio8Z6ETfvxeeW2k+I4="
     },
     "encodeurl": {
       "version": "1.0.1",
@@ -2106,6 +2169,11 @@
         }
       }
     },
+    "event-kit": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/event-kit/-/event-kit-2.4.0.tgz",
+      "integrity": "sha512-ZXd9jxUoc/f/zdLdR3OUcCzT84WnpaNWefquLyE125akIC90sDs8S3T/qihliuVsaj7Osc0z8lLL2fjooE9Z4A=="
+    },
     "execa": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
@@ -2295,6 +2363,93 @@
       "resolved": "https://registry.npmjs.org/find-root/-/find-root-0.1.2.tgz",
       "integrity": "sha1-mNImfP8ZFsyvJ0OzoO6oHXnX3NE="
     },
+    "find-up": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
+      "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+      "requires": {
+        "path-exists": "2.1.0",
+        "pinkie-promise": "2.0.1"
+      }
+    },
+    "first-mate": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/first-mate/-/first-mate-6.3.0.tgz",
+      "integrity": "sha1-3qQ530Rt4OoLi09WOoNPN9CtOT4=",
+      "requires": {
+        "emissary": "1.3.3",
+        "event-kit": "2.4.0",
+        "fs-plus": "2.10.1",
+        "grim": "2.0.2",
+        "oniguruma": "6.2.1",
+        "season": "5.4.1",
+        "underscore-plus": "1.6.6"
+      },
+      "dependencies": {
+        "async": {
+          "version": "1.5.2",
+          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+          "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
+        },
+        "fs-plus": {
+          "version": "2.10.1",
+          "resolved": "https://registry.npmjs.org/fs-plus/-/fs-plus-2.10.1.tgz",
+          "integrity": "sha1-MgR4HXhAYR5jZOe2+wWMljJ8WqU=",
+          "requires": {
+            "async": "1.5.2",
+            "mkdirp": "0.5.1",
+            "rimraf": "2.6.2",
+            "underscore-plus": "1.6.6"
+          }
+        },
+        "optimist": {
+          "version": "0.4.0",
+          "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.4.0.tgz",
+          "integrity": "sha1-y47Dfy/jqphky2eidSUOfhliCiU=",
+          "requires": {
+            "wordwrap": "0.0.3"
+          }
+        },
+        "rimraf": {
+          "version": "2.6.2",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
+          "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+          "requires": {
+            "glob": "7.1.1"
+          }
+        },
+        "season": {
+          "version": "5.4.1",
+          "resolved": "https://registry.npmjs.org/season/-/season-5.4.1.tgz",
+          "integrity": "sha1-S9baYVKn8tbwixQzzi2SBmmFPQ0=",
+          "requires": {
+            "cson-parser": "1.0.9",
+            "fs-plus": "2.10.1",
+            "optimist": "0.4.0"
+          }
+        },
+        "wordwrap": {
+          "version": "0.0.3",
+          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+          "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc="
+        }
+      }
+    },
+    "first-mate-select-grammar": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/first-mate-select-grammar/-/first-mate-select-grammar-1.0.1.tgz",
+      "integrity": "sha1-LdBqgeKd9Y6GZ2hUSr6pukJDzNg=",
+      "requires": {
+        "lodash": "3.10.1"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "3.10.1",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+          "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y="
+        }
+      }
+    },
     "for-each": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.2.tgz",
@@ -2369,11 +2524,36 @@
         }
       }
     },
+    "fs-plus": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/fs-plus/-/fs-plus-3.0.1.tgz",
+      "integrity": "sha1-VMFpxA4ohKZtNSeA0Y3TH5HToQ0=",
+      "requires": {
+        "async": "1.5.2",
+        "mkdirp": "0.5.1",
+        "rimraf": "2.6.2",
+        "underscore-plus": "1.6.6"
+      },
+      "dependencies": {
+        "async": {
+          "version": "1.5.2",
+          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+          "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
+        },
+        "rimraf": {
+          "version": "2.6.2",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
+          "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+          "requires": {
+            "glob": "7.1.1"
+          }
+        }
+      }
+    },
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-      "dev": true
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
     "generate-function": {
       "version": "2.0.0",
@@ -2424,11 +2604,26 @@
       "integrity": "sha1-EWh9uTl235djMSWmsiKKGkv9+iQ=",
       "dev": true
     },
+    "github-slugger": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/github-slugger/-/github-slugger-1.2.0.tgz",
+      "integrity": "sha512-wIaa75k1vZhyPm9yWrD08A5Xnx/V+RmzGrpjQuLemGKSb77Qukiaei58Bogrl/LZSADDfPzKJX8jhLs4CRTl7Q==",
+      "requires": {
+        "emoji-regex": "6.1.1"
+      }
+    },
+    "github-url-to-object": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/github-url-to-object/-/github-url-to-object-4.0.2.tgz",
+      "integrity": "sha1-EeIG1UJjtwGp47fMCaVbs4huDJc=",
+      "requires": {
+        "is-url": "1.2.2"
+      }
+    },
     "glob": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
       "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
-      "dev": true,
       "requires": {
         "fs.realpath": "1.0.0",
         "inflight": "1.0.4",
@@ -2442,7 +2637,6 @@
           "version": "3.0.3",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
           "integrity": "sha1-Kk5AkLlrLbBqnX3wEFWmKnfJt3Q=",
-          "dev": true,
           "requires": {
             "brace-expansion": "1.1.3"
           }
@@ -2469,6 +2663,14 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
       "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU="
+    },
+    "grim": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/grim/-/grim-2.0.2.tgz",
+      "integrity": "sha512-Qj7hTJRfd87E/gUgfvM0YIH/g2UA2SV6niv6BYXk1o6w4mhgv+QyYM1EjOJQljvzgEj4SqSsRWldXIeKHz3e3Q==",
+      "requires": {
+        "event-kit": "2.4.0"
+      }
     },
     "growl": {
       "version": "1.9.2",
@@ -2552,6 +2754,126 @@
       "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
       "dev": true
     },
+    "highlights": {
+      "version": "3.2.0-candidate.1",
+      "resolved": "https://registry.npmjs.org/highlights/-/highlights-3.2.0-candidate.1.tgz",
+      "integrity": "sha512-VW48P0g3cRHwaj7ZmHQhbyfL5r4A6tpvquV7CnOBTxAYHfv3SzC14bCl9c+ex100p1S8xlDO16dHx8Y5vgj21w==",
+      "requires": {
+        "first-mate": "6.3.0",
+        "first-mate-select-grammar": "1.0.1",
+        "fs-plus": "3.0.1",
+        "once": "1.3.3",
+        "season": "6.0.1",
+        "underscore-plus": "1.6.6",
+        "yargs": "4.8.1"
+      },
+      "dependencies": {
+        "camelcase": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
+          "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo="
+        },
+        "graceful-fs": {
+          "version": "4.1.11",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+          "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
+        },
+        "load-json-file": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+          "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "parse-json": "2.2.0",
+            "pify": "2.3.0",
+            "pinkie-promise": "2.0.1",
+            "strip-bom": "2.0.0"
+          }
+        },
+        "path-type": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
+          "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "pify": "2.3.0",
+            "pinkie-promise": "2.0.1"
+          }
+        },
+        "read-pkg": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
+          "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
+          "requires": {
+            "load-json-file": "1.1.0",
+            "normalize-package-data": "2.3.5",
+            "path-type": "1.1.0"
+          }
+        },
+        "read-pkg-up": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
+          "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
+          "requires": {
+            "find-up": "1.1.2",
+            "read-pkg": "1.1.0"
+          }
+        },
+        "strip-bom": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+          "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+          "requires": {
+            "is-utf8": "0.2.1"
+          }
+        },
+        "which-module": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
+          "integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8="
+        },
+        "window-size": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.2.0.tgz",
+          "integrity": "sha1-tDFbtCFKPXBY6+7okuE/ok2YsHU="
+        },
+        "yargs": {
+          "version": "4.8.1",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-4.8.1.tgz",
+          "integrity": "sha1-wMQpJMpKqmsObaFznfshZDn53cA=",
+          "requires": {
+            "cliui": "3.2.0",
+            "decamelize": "1.2.0",
+            "get-caller-file": "1.0.2",
+            "lodash.assign": "4.2.0",
+            "os-locale": "1.4.0",
+            "read-pkg-up": "1.0.1",
+            "require-directory": "2.1.1",
+            "require-main-filename": "1.0.1",
+            "set-blocking": "2.0.0",
+            "string-width": "1.0.2",
+            "which-module": "1.0.0",
+            "window-size": "0.2.0",
+            "y18n": "3.2.1",
+            "yargs-parser": "2.4.1"
+          }
+        },
+        "yargs-parser": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-2.4.1.tgz",
+          "integrity": "sha1-hVaN488VD/SfpRgl8DqMiA3cxcQ=",
+          "requires": {
+            "camelcase": "3.0.0",
+            "lodash.assign": "4.2.0"
+          }
+        }
+      }
+    },
+    "highlights-tokens": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/highlights-tokens/-/highlights-tokens-1.0.1.tgz",
+      "integrity": "sha1-kJGf6UlUz/9RjWVS5L6vSmVNXeo="
+    },
     "hoek": {
       "version": "2.16.3",
       "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
@@ -2561,6 +2883,11 @@
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.1.5.tgz",
       "integrity": "sha1-C6gdkNouJas0ozLm7HeTbhWYEYs="
+    },
+    "html-entities": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-1.2.1.tgz",
+      "integrity": "sha1-DfKTUfByEWNRXfueVUPl9u7VFi8="
     },
     "htmlparser2": {
       "version": "3.8.3",
@@ -2675,6 +3002,14 @@
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
       "integrity": "sha1-BTfLedr1m1mhpRff9wbIbsA5Fi4="
     },
+    "innertext": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/innertext/-/innertext-1.0.2.tgz",
+      "integrity": "sha1-EaGXsxQ6WTY2+6XVkhODXmlUWAo=",
+      "requires": {
+        "html-entities": "1.2.1"
+      }
+    },
     "invert-kv": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
@@ -2744,6 +3079,11 @@
         "xtend": "4.0.1"
       }
     },
+    "is-plain-obj": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
+      "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4="
+    },
     "is-promise": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
@@ -2763,6 +3103,16 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
       "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
+    },
+    "is-url": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/is-url/-/is-url-1.2.2.tgz",
+      "integrity": "sha1-SYkFpZO/R8wtnn9zg3K792lsfyY="
+    },
+    "is-utf8": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
+      "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI="
     },
     "isarray": {
       "version": "0.0.1",
@@ -3098,6 +3448,41 @@
         "is-buffer": "1.1.4"
       }
     },
+    "language-dart": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/language-dart/-/language-dart-0.1.1.tgz",
+      "integrity": "sha1-AmoPeweMxkuE9AIOUvchb+xl1bY="
+    },
+    "language-erlang": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/language-erlang/-/language-erlang-2.0.0.tgz",
+      "integrity": "sha1-pf/wjdBd78I/6jYyzc7JlEdaRzA="
+    },
+    "language-glsl": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/language-glsl/-/language-glsl-2.0.1.tgz",
+      "integrity": "sha1-1OcXs3AJO2p5TipK/r/8ktN5Jh0="
+    },
+    "language-haxe": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/language-haxe/-/language-haxe-0.2.1.tgz",
+      "integrity": "sha1-InYB15SDurv1OylyUopHG+42IO0="
+    },
+    "language-ini": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/language-ini/-/language-ini-1.16.0.tgz",
+      "integrity": "sha1-5e8kjp5YaTFkfHzG9s1ZitggmVc="
+    },
+    "language-rust": {
+      "version": "0.4.12",
+      "resolved": "https://registry.npmjs.org/language-rust/-/language-rust-0.4.12.tgz",
+      "integrity": "sha512-WLVVa5ftxhPiYMNjjfwr+GCVAPy/vFvP/FTAU4P+JiI9bfbZoF5QzEWi6n3Bb3E1S8Us3UGtoi78vRhEZMqnmQ=="
+    },
+    "language-stylus": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/language-stylus/-/language-stylus-0.5.2.tgz",
+      "integrity": "sha1-fNLLUUXxaO4QRkHgwisCwmYQVpc="
+    },
     "lazy-cache": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
@@ -3113,6 +3498,11 @@
         "invert-kv": "1.0.0"
       }
     },
+    "leven": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/leven/-/leven-2.1.0.tgz",
+      "integrity": "sha1-wuep93IJTe6dNCAq6KzORoeHVYA="
+    },
     "levn": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
@@ -3121,6 +3511,14 @@
       "requires": {
         "prelude-ls": "1.1.2",
         "type-check": "0.3.2"
+      }
+    },
+    "linkify-it": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-2.0.3.tgz",
+      "integrity": "sha1-2UpGSPmxwXnWT6lykSaL22zpQ08=",
+      "requires": {
+        "uc.micro": "1.0.3"
       }
     },
     "load-json-file": {
@@ -3307,6 +3705,11 @@
       "integrity": "sha1-UgOte6Ql+uhCRg5pbbnPPmqsBXw=",
       "dev": true
     },
+    "lodash.assign": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
+      "integrity": "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc="
+    },
     "lodash.create": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/lodash.create/-/lodash.create-3.1.1.tgz",
@@ -3317,6 +3720,11 @@
         "lodash._basecreate": "3.0.3",
         "lodash._isiterateecall": "3.0.9"
       }
+    },
+    "lodash.defaults": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
+      "integrity": "sha1-0JF4cW/+pN3p5ft7N/bwgCJ0WAw="
     },
     "lodash.isarguments": {
       "version": "3.1.0",
@@ -3345,6 +3753,16 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
       "integrity": "sha1-DdOXEhPHxW34gJd9UEyI+0cal6w="
+    },
+    "lodash.pickby": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.pickby/-/lodash.pickby-4.6.0.tgz",
+      "integrity": "sha1-feoh2MGNdwOifHBMFdO4SmfjOv8="
+    },
+    "lodash.repeat": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/lodash.repeat/-/lodash.repeat-4.1.0.tgz",
+      "integrity": "sha1-/H3oEx2MisB+S0n3T/6CnR8r7EQ="
     },
     "lolex": {
       "version": "1.3.2",
@@ -3386,10 +3804,88 @@
         "es5-ext": "0.10.11"
       }
     },
-    "marked": {
-      "version": "0.3.6",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.6.tgz",
-      "integrity": "sha1-ssbGGPzOzk74bE/Gy4p8v1rtqNc="
+    "markdown-it": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-8.4.0.tgz",
+      "integrity": "sha512-tNuOCCfunY5v5uhcO2AUMArvKAyKMygX8tfup/JrgnsDqcCATQsAExBq7o5Ml9iMmO82bk6jYNLj6khcrl0JGA==",
+      "requires": {
+        "argparse": "1.0.9",
+        "entities": "1.1.1",
+        "linkify-it": "2.0.3",
+        "mdurl": "1.0.1",
+        "uc.micro": "1.0.3"
+      },
+      "dependencies": {
+        "argparse": {
+          "version": "1.0.9",
+          "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
+          "integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
+          "requires": {
+            "sprintf-js": "1.0.3"
+          }
+        },
+        "entities": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz",
+          "integrity": "sha1-blwtClYhtdra7O+AuQ7ftc13cvA="
+        }
+      }
+    },
+    "markdown-it-emoji": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/markdown-it-emoji/-/markdown-it-emoji-1.4.0.tgz",
+      "integrity": "sha1-m+4OmpkKljupbfaYDE/dsF37Tcw="
+    },
+    "markdown-it-expand-tabs": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/markdown-it-expand-tabs/-/markdown-it-expand-tabs-1.0.12.tgz",
+      "integrity": "sha1-9UvS8wP4WO5nmMor2D/nAUSBTKA=",
+      "requires": {
+        "lodash.repeat": "4.1.0"
+      }
+    },
+    "markdown-it-lazy-headers": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/markdown-it-lazy-headers/-/markdown-it-lazy-headers-0.1.3.tgz",
+      "integrity": "sha1-5w3U2nnIepzoLKRwG4t8Di1yKXs="
+    },
+    "markdown-it-task-lists": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/markdown-it-task-lists/-/markdown-it-task-lists-2.0.1.tgz",
+      "integrity": "sha1-qc5/Vc3p9F4PymKQcdEdP9WmlBY="
+    },
+    "marky-markdown": {
+      "version": "11.3.2",
+      "resolved": "https://registry.npmjs.org/marky-markdown/-/marky-markdown-11.3.2.tgz",
+      "integrity": "sha512-VsDoIOFH28H40ZtheXpSaP6Q/EV5bRZgntr6spdZ1oNXS3+3PaINbFkdHCITdE8QKi1V9z+3pn6WnqLywXj7qQ==",
+      "requires": {
+        "atom-language-diff": "1.0.2",
+        "atom-language-nginx": "0.6.1",
+        "github-slugger": "1.2.0",
+        "github-url-to-object": "4.0.2",
+        "highlights": "3.2.0-candidate.1",
+        "highlights-tokens": "1.0.1",
+        "innertext": "1.0.2",
+        "is-plain-obj": "1.1.0",
+        "language-dart": "0.1.1",
+        "language-erlang": "2.0.0",
+        "language-glsl": "2.0.1",
+        "language-haxe": "0.2.1",
+        "language-ini": "1.16.0",
+        "language-rust": "0.4.12",
+        "language-stylus": "0.5.2",
+        "lodash.assign": "4.2.0",
+        "lodash.defaults": "4.2.0",
+        "lodash.pickby": "4.6.0",
+        "markdown-it": "8.4.0",
+        "markdown-it-emoji": "1.4.0",
+        "markdown-it-expand-tabs": "1.0.12",
+        "markdown-it-lazy-headers": "0.1.3",
+        "markdown-it-task-lists": "2.0.1",
+        "property-ttl": "1.0.0",
+        "sanitize-html": "1.14.1",
+        "similarity": "1.1.1"
+      }
     },
     "md5": {
       "version": "2.2.1",
@@ -3400,6 +3896,11 @@
         "crypt": "0.0.2",
         "is-buffer": "1.1.4"
       }
+    },
+    "mdurl": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-1.0.1.tgz",
+      "integrity": "sha1-/oWy7HWlkDfyrf7BAP1sYBdhFS4="
     },
     "media-typer": {
       "version": "0.3.0",
@@ -3527,6 +4028,11 @@
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
       "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
     },
+    "mixto": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/mixto/-/mixto-1.0.0.tgz",
+      "integrity": "sha1-wyDvYbUvKJj1IuF9i7xtUG2EJbY="
+    },
     "mkdirp": {
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
@@ -3618,6 +4124,11 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/mustache/-/mustache-2.3.0.tgz",
       "integrity": "sha1-QCj3d4sXcIpImTCm5SrDvKDaQdA="
+    },
+    "nan": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.7.0.tgz",
+      "integrity": "sha1-2Vv3IeyHfgjbJ27T/G63j5CDrUY="
     },
     "native-promise-only": {
       "version": "0.8.1",
@@ -3731,6 +4242,14 @@
         "wrappy": "1.0.1"
       }
     },
+    "oniguruma": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/oniguruma/-/oniguruma-6.2.1.tgz",
+      "integrity": "sha1-pQ7mlkKEStHSUmhaqxhxcbBuzgQ=",
+      "requires": {
+        "nan": "2.7.0"
+      }
+    },
     "openurl": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/openurl/-/openurl-1.1.1.tgz",
@@ -3825,6 +4344,14 @@
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.2.tgz",
       "integrity": "sha1-/CidTtiZMRlGDBViUyYs3I3mW/M="
+    },
+    "path-exists": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
+      "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+      "requires": {
+        "pinkie-promise": "2.0.1"
+      }
     },
     "path-is-absolute": {
       "version": "1.0.0",
@@ -3998,6 +4525,52 @@
         "asap": "2.0.6"
       }
     },
+    "property-accessors": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/property-accessors/-/property-accessors-1.1.3.tgz",
+      "integrity": "sha1-Hd6EAkYxhlkJ7zBwM2VoDF+SixU=",
+      "requires": {
+        "es6-weak-map": "0.1.4",
+        "mixto": "1.0.0"
+      },
+      "dependencies": {
+        "es6-iterator": {
+          "version": "0.1.3",
+          "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-0.1.3.tgz",
+          "integrity": "sha1-1vWLjE/EE8JJtLqhl2j45NfIlE4=",
+          "requires": {
+            "d": "0.1.1",
+            "es5-ext": "0.10.11",
+            "es6-symbol": "2.0.1"
+          }
+        },
+        "es6-symbol": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-2.0.1.tgz",
+          "integrity": "sha1-dhtcZ8/U8dGK+yNPaR1nhoLLO/M=",
+          "requires": {
+            "d": "0.1.1",
+            "es5-ext": "0.10.11"
+          }
+        },
+        "es6-weak-map": {
+          "version": "0.1.4",
+          "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-0.1.4.tgz",
+          "integrity": "sha1-cGzvnpmqI2undmwjnIueKG6n0ig=",
+          "requires": {
+            "d": "0.1.1",
+            "es5-ext": "0.10.11",
+            "es6-iterator": "0.1.3",
+            "es6-symbol": "2.0.1"
+          }
+        }
+      }
+    },
+    "property-ttl": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/property-ttl/-/property-ttl-1.0.0.tgz",
+      "integrity": "sha1-/ssxjH1RtKgPwHf8SkaP8TCURwA="
+    },
     "proto-list": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
@@ -4115,6 +4688,11 @@
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.0.tgz",
       "integrity": "sha512-/aA0kLeRb5N9K0d4fw7ooEbI+xDe+DKD499EQqygGqeS8N3xto15p09uY2xj7ixP81sNPXvRLnAQIqdVStgb1A=="
+    },
+    "regexp-quote": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/regexp-quote/-/regexp-quote-0.0.0.tgz",
+      "integrity": "sha1-Hg9GUMhi3L/tVP1CsUjpuxch/PI="
     },
     "repeat-string": {
       "version": "1.6.1",
@@ -4253,6 +4831,70 @@
       "integrity": "sha1-vsEf3IOp/aBjQBIQ5AF2wwJNFWc=",
       "dev": true
     },
+    "sanitize-html": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/sanitize-html/-/sanitize-html-1.14.1.tgz",
+      "integrity": "sha1-cw/6Ikm98YMz7/5FsoYXPJxa0Lg=",
+      "requires": {
+        "htmlparser2": "3.9.2",
+        "regexp-quote": "0.0.0",
+        "xtend": "4.0.1"
+      },
+      "dependencies": {
+        "entities": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz",
+          "integrity": "sha1-blwtClYhtdra7O+AuQ7ftc13cvA="
+        },
+        "htmlparser2": {
+          "version": "3.9.2",
+          "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.9.2.tgz",
+          "integrity": "sha1-G9+HrMoPP55T+k/M6w9LTLsAszg=",
+          "requires": {
+            "domelementtype": "1.3.0",
+            "domhandler": "2.3.0",
+            "domutils": "1.5.1",
+            "entities": "1.1.1",
+            "inherits": "2.0.1",
+            "readable-stream": "2.3.3"
+          }
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+        },
+        "readable-stream": {
+          "version": "2.3.3",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
+          "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
+          "requires": {
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "1.0.7",
+            "safe-buffer": "5.1.1",
+            "string_decoder": "1.0.3",
+            "util-deprecate": "1.0.2"
+          },
+          "dependencies": {
+            "inherits": {
+              "version": "2.0.3",
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+              "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+            }
+          }
+        },
+        "string_decoder": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+          "requires": {
+            "safe-buffer": "5.1.1"
+          }
+        }
+      }
+    },
     "scmp": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/scmp/-/scmp-0.0.3.tgz",
@@ -4267,6 +4909,31 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/sdp-transform/-/sdp-transform-2.3.0.tgz",
       "integrity": "sha1-V6lXWUIEHYV3qGnXx01MOgvYiPY="
+    },
+    "season": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/season/-/season-6.0.1.tgz",
+      "integrity": "sha512-mOe8Cx3eSUNwvs8fo9EMhzTXRv64tIibYWG+HEyYs8il7sG5ZpONaJRM6BTCzesptk0TVJk8dj1nNltyWAdsYA==",
+      "requires": {
+        "cson-parser": "1.0.9",
+        "fs-plus": "3.0.1",
+        "optimist": "0.4.0"
+      },
+      "dependencies": {
+        "optimist": {
+          "version": "0.4.0",
+          "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.4.0.tgz",
+          "integrity": "sha1-y47Dfy/jqphky2eidSUOfhliCiU=",
+          "requires": {
+            "wordwrap": "0.0.3"
+          }
+        },
+        "wordwrap": {
+          "version": "0.0.3",
+          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+          "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc="
+        }
+      }
     },
     "semver": {
       "version": "5.0.3",
@@ -4490,6 +5157,14 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
       "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
+    },
+    "similarity": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/similarity/-/similarity-1.1.1.tgz",
+      "integrity": "sha1-QcNwtPXQ+QTT1JB/lvLj0yvpuTE=",
+      "requires": {
+        "leven": "2.1.0"
+      }
     },
     "sinon": {
       "version": "1.17.7",
@@ -4950,6 +5625,11 @@
       "resolved": "https://registry.npmjs.org/typical/-/typical-2.6.1.tgz",
       "integrity": "sha1-XAgOXWYcu+OCWdLnCjxyU+hziB0="
     },
+    "uc.micro": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.3.tgz",
+      "integrity": "sha1-ftUNXg+an7ClczeSWfKndFjVAZI="
+    },
     "uglify-js": {
       "version": "2.7.5",
       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.7.5.tgz",
@@ -5052,6 +5732,21 @@
       "version": "1.8.3",
       "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
       "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI="
+    },
+    "underscore-plus": {
+      "version": "1.6.6",
+      "resolved": "https://registry.npmjs.org/underscore-plus/-/underscore-plus-1.6.6.tgz",
+      "integrity": "sha1-ZezeG9xEGjXYnmUP1w3PE65Dmn0=",
+      "requires": {
+        "underscore": "1.6.0"
+      },
+      "dependencies": {
+        "underscore": {
+          "version": "1.6.0",
+          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz",
+          "integrity": "sha1-izixDKze9jM3uLJOT/htRa6lKag="
+        }
+      }
     },
     "unique-concat": {
       "version": "0.2.2",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "cfenv": "^1.0.3",
     "dotenv": "^4.0.0",
     "lodash": "^4.17.4",
-    "marked": "^0.3.6",
+    "marky-markdown": "^11.3.2",
     "moment": "^2.11.2",
     "moment-timezone": "^0.5.1",
     "mustache": "^2.2.1",


### PR DESCRIPTION
The [marked](https://npm.im/marked) Markdown rendering library has had a DOS vulnerability for quite a while.  While that vulnerability was not a concern for us (the rendering is done on static, controlled content, rather than anything user-provided), having the big red thing on the project front page plus a dependence on an unmaintained, abandoned project is no fun.  Switched to [marky-markdown](https://npm.im/marky-markdown), which is used and maintained by npm, so it stands to be maintained in the long term.