### PR TITLE
Allow military time with colon to be used for scheduling standups

### DIFF
--- a/features/helper-time.feature
+++ b/features/helper-time.feature
@@ -2,19 +2,31 @@ Feature: Time Helper, parsing a string
   I want the time helper to parse a time from a string
   I want the time helper to convert a time to a formatted string
 
-  Scenario Outline: Parsing a string to a time
+  Scenario Outline: Parsing a string to a time (negative examples)
     Given the string <time_string>
       When I try to parse it
-      Then the time <status> parse
+      Then the time should not parse
 
     Examples:
       | time_string | status     |
+      | 8301        | should not |
       | 830         | should not |
-      | 8:30        | should not |
-      | 830am       | should     |
-      | 830 am      | should     |
-      | 0830        | should     |
-      | 0830 M W F  | should     |
+      | 830am       | should not |
+      | 830 am      | should not |
+
+  Scenario Outline: Parsing a string to a time (positive examples)
+    Given the string <time_string>
+      When I try to parse it
+      Then the time should parse
+      And the parsed time and days should be <expected_time_days>
+
+    Examples:
+      | time_string           | expected_time_days                                |
+      | 8:30                  | 8:30 am Monday,Tuesday,Wednesday,Thursday,Friday  |
+      | 0930 Mo Tu Th         | 9:30 am Monday,Tuesday,Thursday                   |
+      | 9:30 pm Mo Tu Th      | 9:30 pm Monday,Tuesday,Thursday                   |
+      | 1330 W F              | 1:30 pm Wednesday,Friday                          |
+      | 1845 Wednesday Friday | 6:45 pm Wednesday,Friday                          |
 
   # The following scenarios match patterns instead of values
   # known ahead of time.  To match a pattern, they use a

--- a/features/steps/helper-time.js
+++ b/features/steps/helper-time.js
@@ -57,6 +57,15 @@ module.exports = function() {
     }
   });
 
+  this.Then(/^the parsed time and days should be (.*)$/, function(expectedTimeAndDays) {
+    //in format HH:mm am|pm Monday,Tuesday,Friday
+    let actual = `${_parsedValue.time.format('h:mm a')} ${_parsedValue.days.join(',')}`;
+    if(actual !== expectedTimeAndDays) {
+      throw new Error('Expected "' + expectedTimeAndDays + '" to equal "' + actual + '"');
+    }
+    return true;
+  });
+
   this.Then(/^the result matches (.*)$/, function(pattern) {
     if(!_formattedTime.match(new RegExp(pattern))) {
       throw new Error('Expected "' + _formattedTime + '" to match "' + pattern + '"');

--- a/lib/helpers/time.js
+++ b/lib/helpers/time.js
@@ -4,7 +4,7 @@ var moment = require('moment-timezone');
 var timezone = process.env.TIMEZONE || 'America/New_York';
 
 function getTimeFromString(str) {
-  var time = str.match(/((\d+|:)*(\s)?((a|p)m)|\d{4})/gi);
+  var time = str.match(/((\d+|:)*(\s)?((a|p)m)?|\d{4})/gi);
   var daysPortion = str.replace(time, '').trim();
 
   if(time) {

--- a/lib/helpers/time.js
+++ b/lib/helpers/time.js
@@ -4,7 +4,7 @@ var moment = require('moment-timezone');
 var timezone = process.env.TIMEZONE || 'America/New_York';
 
 function getTimeFromString(str) {
-  var time = str.match(/((\d+|:)*(\s)?((a|p)m)?|\d{4})/gi);
+  var time = str.match(/(\d\d?:\d\d\s*(?:[ap]m)?|\d{4})/gi);
   var daysPortion = str.replace(time, '').trim();
 
   if(time) {


### PR DESCRIPTION
e.g. `schedule standup 13:00` will schedule it for 1:00 pm.  Using am/pm still works - this is just added functionality